### PR TITLE
Add persisted logs and rename SDK package to dygo

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -79,7 +79,7 @@ Business-specific behavior should live in apps built on top of dygo.
 
 Use `internal/` for dygo implementation details.
 
-Only expose stable public APIs through `pkg/sdk/`.
+Only expose stable public APIs through `pkg/dygo/`.
 
 ### 3. Everything important should be observable
 

--- a/apps/core/docs/index.md
+++ b/apps/core/docs/index.md
@@ -2,13 +2,14 @@
 
 Core is the required system App for dygo.
 
-It provides the foundation dygo needs before business apps can run: system metadata, users, roles, permissions, sessions, activity history, installed App state, fixtures, and patches.
+It provides the foundation dygo needs before business apps can run: system metadata, users, roles, permissions, sessions, activity history, persisted Logs, installed App state, fixtures, and patches.
 
 The first Entity scaffold is metadata-only. It defines these Core system contracts:
 
 ```txt
 app
 activity
+log
 entity
 field
 index
@@ -21,6 +22,6 @@ permission
 session
 ```
 
-These contracts create Core database tables through dygo's metadata-driven schema sync. The `activity` contract is the append-only storage shape for Record history and product timeline events.
+These contracts create Core database tables through dygo's metadata-driven schema sync. The `activity` contract is the append-only storage shape for Record history and product timeline events. The `log` contract stores framework and app diagnostics.
 
 `patch-run` is the first app lifecycle ledger. It records successfully applied app patches so later patch planning and application can detect pending patches and checksum drift.

--- a/apps/core/entities/log/entity.yml
+++ b/apps/core/entities/log/entity.yml
@@ -1,0 +1,78 @@
+label: Log
+description: Persisted framework and app diagnostic event.
+icon: file-text
+is-system: true
+name:
+  strategy: random
+fields:
+  - name: type
+    label: Type
+    type: select
+    required: true
+    options:
+      values:
+        - Debug
+        - Info
+        - Warning
+        - Error
+        - Panic
+
+  - name: source
+    label: Source
+    type: select
+    required: true
+    options:
+      values:
+        - Framework
+        - SDK
+        - HTTP
+        - Job
+        - Hook
+        - CLI
+        - Studio
+
+  - name: app
+    label: App
+    type: link
+    options:
+      entity: app
+      foreign-key: false
+
+  - name: title
+    label: Title
+    type: text
+    required: true
+
+  - name: message
+    label: Message
+    type: long-text
+
+  - name: trace-id
+    label: Trace ID
+    type: text
+
+  - name: reference-entity
+    label: Reference Entity
+    type: link
+    options:
+      entity: entity
+      foreign-key: false
+
+  - name: reference-record-id
+    label: Reference Record ID
+    type: bigint
+
+  - name: reference-record-name
+    label: Reference Record Name
+    type: text
+
+  - name: actor
+    label: Actor
+    type: link
+    options:
+      entity: user
+      foreign-key: false
+
+  - name: metadata
+    label: Metadata
+    type: json

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -436,6 +436,45 @@ ALTER TABLE public.language ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
 
 
 --
+-- Name: log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.log (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    type text NOT NULL,
+    source text NOT NULL,
+    app_id bigint,
+    title text NOT NULL,
+    message text,
+    trace_id text,
+    reference_entity_id bigint,
+    reference_record_id bigint,
+    reference_record_name text,
+    actor_id bigint,
+    metadata jsonb,
+    CONSTRAINT log_source_check CHECK ((source = ANY (ARRAY['Framework'::text, 'SDK'::text, 'HTTP'::text, 'Job'::text, 'Hook'::text, 'CLI'::text, 'Studio'::text]))),
+    CONSTRAINT log_type_check CHECK ((type = ANY (ARRAY['Debug'::text, 'Info'::text, 'Warning'::text, 'Error'::text, 'Panic'::text])))
+);
+
+
+--
+-- Name: log_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.log ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
 -- Name: naming_series; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -554,6 +593,49 @@ CREATE TABLE public.role (
 
 ALTER TABLE public.role ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
     SEQUENCE NAME public.role_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: schedule; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schedule (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    app_id bigint NOT NULL,
+    key text NOT NULL,
+    source text DEFAULT 'file'::text NOT NULL,
+    label text NOT NULL,
+    description text,
+    cron text NOT NULL,
+    timezone text NOT NULL,
+    job_id bigint NOT NULL,
+    job_app_name text NOT NULL,
+    job_name text NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    retired boolean DEFAULT false NOT NULL,
+    next_run_at timestamp with time zone,
+    last_run_at timestamp with time zone,
+    last_error text,
+    actor_id bigint,
+    CONSTRAINT schedule_source_check CHECK ((source = ANY (ARRAY['file'::text, 'studio'::text, 'system'::text])))
+);
+
+
+--
+-- Name: schedule_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.schedule ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME public.schedule_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -895,6 +977,22 @@ ALTER TABLE ONLY public.language
 
 
 --
+-- Name: log log_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.log
+    ADD CONSTRAINT log_name_key UNIQUE (name);
+
+
+--
+-- Name: log log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.log
+    ADD CONSTRAINT log_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: naming_series naming_series_key_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -972,6 +1070,30 @@ ALTER TABLE ONLY public.role
 
 ALTER TABLE ONLY public.role
     ADD CONSTRAINT role_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schedule schedule_app_key_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schedule
+    ADD CONSTRAINT schedule_app_key_key UNIQUE (app_id, key);
+
+
+--
+-- Name: schedule schedule_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schedule
+    ADD CONSTRAINT schedule_name_key UNIQUE (name);
+
+
+--
+-- Name: schedule schedule_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schedule
+    ADD CONSTRAINT schedule_pkey PRIMARY KEY (id);
 
 
 --
@@ -1333,6 +1455,83 @@ CREATE INDEX role_enabled_idx ON public.role USING btree (enabled);
 
 
 --
+-- Name: schedule_actor_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_actor_id_idx ON public.schedule USING btree (actor_id);
+
+
+--
+-- Name: schedule_app_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_app_id_idx ON public.schedule USING btree (app_id);
+
+
+--
+-- Name: schedule_due; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_due ON public.schedule USING btree (enabled, retired, next_run_at);
+
+
+--
+-- Name: schedule_enabled_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_enabled_idx ON public.schedule USING btree (enabled);
+
+
+--
+-- Name: schedule_job_app_name_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_job_app_name_idx ON public.schedule USING btree (job_app_name);
+
+
+--
+-- Name: schedule_job_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_job_id_idx ON public.schedule USING btree (job_id);
+
+
+--
+-- Name: schedule_job_name_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_job_name_idx ON public.schedule USING btree (job_name);
+
+
+--
+-- Name: schedule_key_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_key_idx ON public.schedule USING btree (key);
+
+
+--
+-- Name: schedule_next_run_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_next_run_at_idx ON public.schedule USING btree (next_run_at);
+
+
+--
+-- Name: schedule_retired_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_retired_idx ON public.schedule USING btree (retired);
+
+
+--
+-- Name: schedule_source_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX schedule_source_idx ON public.schedule USING btree (source);
+
+
+--
 -- Name: session_status_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1476,6 +1675,22 @@ ALTER TABLE ONLY public.permission
 
 ALTER TABLE ONLY public.permission
     ADD CONSTRAINT permission_role_id_fkey FOREIGN KEY (role_id) REFERENCES public.role(id);
+
+
+--
+-- Name: schedule schedule_app_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schedule
+    ADD CONSTRAINT schedule_app_id_fkey FOREIGN KEY (app_id) REFERENCES public.app(id);
+
+
+--
+-- Name: schedule schedule_job_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schedule
+    ADD CONSTRAINT schedule_job_id_fkey FOREIGN KEY (job_id) REFERENCES public.job(id);
 
 
 --

--- a/docs/app-model.md
+++ b/docs/app-model.md
@@ -90,7 +90,7 @@ Entity metadata uses singular keys only. Studio record URLs use `route.slug`, de
 
 Every Record also has a system `name` generated from Entity `name` metadata. Apps can choose manual names, random names, format names, or series names. The numeric `id` remains dygo's internal primary key.
 
-Hooks are app-owned Go code inside Entity bundles. A file such as `entities/lead/hooks.go` belongs to Entity `lead`. dygo validates this convention, but the code must still be compiled into a project runner through `pkg/sdk/runtime`; dygo does not dynamically load Go source files.
+Hooks are app-owned Go code inside Entity bundles. A file such as `entities/lead/hooks.go` belongs to Entity `lead`. dygo validates this convention, but the code must still be compiled into a project runner through `pkg/dygo/runtime`; dygo does not dynamically load Go source files.
 
 Patches are app-owned lifecycle changes for unsafe transitions that metadata cannot infer, such as renames, drops, destructive type changes, and data backfills. See [Explicit Patches](patches.md) for the v1 runner workflow.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -132,7 +132,7 @@ config/queues.yml
 
 Job and Schedule files do not create per-Job tables. They sync into Core metadata records after the Entity schema plan succeeds.
 
-During `dygo db migrate`, dygo loads every discovered App from `apps/` and `.dygo/apps/`, then creates or updates tables from each App's Entity metadata. Core is handled this way too: `apps/core/entities/` is the source for Core tables such as `app`, `activity`, `entity`, `field`, `index`, `constraint`, `job`, `job-execution`, `schedule`, `naming-series`, `patch-run`, `user`, `role`, `permission`, and `session`.
+During `dygo db migrate`, dygo loads every discovered App from `apps/` and `.dygo/apps/`, then creates or updates tables from each App's Entity metadata. Core is handled this way too: `apps/core/entities/` is the source for Core tables such as `app`, `activity`, `log`, `entity`, `field`, `index`, `constraint`, `job`, `job-execution`, `schedule`, `naming-series`, `patch-run`, `user`, `role`, `permission`, and `session`.
 
 Preview metadata sync:
 

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -119,7 +119,7 @@ dygo/                           - Framework repository root
     core/                       - Core platform app
     studio/                     - Studio web app
   pkg/                          - Public Go API surface
-    sdk/                        - App hook and Job SDK
+    dygo/                       - App hook, Job, and logging API
   config/                       - Framework runtime config files
     secrets/                    - Encrypted dev secrets
     github.yml                  - GitHub repository and project board metadata

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Use this index to find the right document for the task. The docs are kept in the
 - [Server](server.md) explains `dygo dev`, `dygo serve`, the health endpoint, auth, metadata APIs, and Record APIs.
 - [Auth](auth.md) explains Administrator bootstrap, session login, and authenticated API identity.
 - [Records](records.md) explains the metadata-powered Record CRUD API.
+- [Logs](logs.md) explains persisted framework and app diagnostic events.
 - [Encrypted Secrets](secrets.md) explains repo-stored encrypted secrets and `dygo secret`.
 
 ## Jobs And Automation

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Use this index to find the right document for the task. The docs are kept in the
 - [Metadata Authoring](metadata-authoring.md) explains JSON Schemas and editor support for dygo YAML files.
 - [Fixtures](fixtures.md) explains app-owned seed Records and `dygo fixture apply`.
 - [Record Hooks](record-hooks.md) explains compiled app Record hooks and the `entities/<entity>/hooks.go` convention.
-- [App SDK](sdk.md) explains the Go package app code uses for hooks, Jobs, and Record access.
+- [App SDK](sdk.md) explains the Go package app code uses for hooks, Jobs, Record access, and Logs.
 
 ## Run The Platform
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -39,10 +39,10 @@ package job
 import (
 	"context"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-func Run(ctx context.Context, job sdk.JobExecution) error {
+func Run(ctx context.Context, job dygo.JobExecution) error {
 	return nil
 }
 ```
@@ -53,7 +53,7 @@ Generated runner wiring registers the handler by app and Job key:
 registry.RegisterJob("crm", "send-welcome-email", crmsendwelcomeemailjob.Run)
 ```
 
-Custom project runners can register Jobs through `pkg/sdk/runtime.Options`, parallel to Record hook registrars.
+Custom project runners can register Jobs through `pkg/dygo/runtime.Options`, parallel to Record hook registrars.
 
 ## job.yml Reference
 
@@ -267,8 +267,8 @@ internal/jobs                - job.yml reader, validator, and shared Job metadat
 internal/jobgen              - Job scaffold and runner wiring generator
 internal/runnergen           - shared generated project runner renderer
 internal/cli                 - Job commands
-pkg/sdk                      - public Job types and registration API
-pkg/sdk/runtime              - project runner options for compiled Jobs
+pkg/dygo                      - public Job types and registration API
+pkg/dygo/runtime              - project runner options for compiled Jobs
 ```
 
 ## Coming Soon

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,203 @@
+# Logs
+
+Logs are persisted framework and app diagnostic events.
+
+dygo stores Logs as Core Records so operators, builders, and agents can inspect runtime behavior in Studio without leaving the app. Logs are intentionally generic: the same Entity should hold framework errors, app information, Job diagnostics, hook failures, HTTP request problems, and future operational events.
+
+The Log Entity is a heavily dogfooded Core Entity. dygo should use it for its own runtime diagnostics before asking app developers to rely on it.
+
+## Why Logs Exist
+
+Activity answers "what happened to this Record?"
+
+Logs answer "what happened inside the system?"
+
+Use Activity for product timelines and Record history. Use Logs for diagnostics, troubleshooting, and operational visibility.
+
+Examples:
+
+- an app hook catches a validation service failure
+- a Job retries after a third-party API timeout
+- a user-facing request fails with an unexpected internal error
+- dygo detects invalid metadata during runtime startup
+- a developer records useful context while testing a feature
+
+## Log Entity
+
+The Core app owns a system Entity named `log`.
+
+The Entity should be append-only by default. App code and framework code create Logs; normal app workflows should not edit them.
+
+Proposed fields:
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `type` | `select` | yes | Log type such as `debug`, `info`, `warning`, `error`, or `panic`. |
+| `source` | `select` | yes | Where the Log came from, such as `framework`, `sdk`, `http`, `job`, `hook`, `cli`, `worker`, or `studio`. |
+| `title` | `text` | yes | Short human-facing summary. |
+| `message` | `long-text` | no | Longer explanation or plain text detail. |
+| `error` | `long-text` | no | Error string, stack trace, or traceback text. |
+| `trace-id` | `text` | no | Correlation ID shared across request, Job, hook, and nested work. |
+| `reference-entity` | `link` | no | Optional Core Entity reference for the related Record type. |
+| `reference-record-id` | `bigint` | no | Optional internal Record ID for the related Record. |
+| `reference-record-name` | `text` | no | Optional stable Record name for the related Record. |
+| `actor` | `link` | no | Optional User that caused the event. |
+| `metadata` | `json` | no | Structured context that does not deserve first-class fields yet. |
+
+`reference-entity` and `actor` should use `foreign-key: false` so old Logs survive target deletion, the same pattern used by Activity history.
+
+Expected indexes:
+
+| Index | Fields | Purpose |
+| --- | --- | --- |
+| `by-type-created` | `type`, `created-at` | Filter recent errors, warnings, or info Logs. |
+| `by-source-created` | `source`, `created-at` | Inspect one runtime surface. |
+| `by-trace` | `trace-id` | Follow a request or Job across multiple Logs. |
+| `by-reference` | `reference-entity`, `reference-record-id` | Show Logs related to one Record. |
+
+## Types
+
+Initial Log types:
+
+```txt
+debug
+info
+warning
+error
+panic
+```
+
+`debug` is for local or temporary detail. It should be easy to disable or retain for a shorter time.
+
+`info` is for useful operational breadcrumbs.
+
+`warning` is for recoverable problems that may need attention.
+
+`error` is for failed operations.
+
+`panic` is for recovered crashes or unrecoverable code paths that dygo managed to capture.
+
+The type list can grow later, but v1 should stay small so Studio filters and retention policies remain simple.
+
+## SDK
+
+The SDK should make writing Logs simple. App code should not need to know the Core Entity fields or call generic Record APIs directly for common cases.
+
+Intended ergonomic shape:
+
+```go
+sdk.Info(ctx, "Customer import started")
+sdk.Error(ctx, "Customer import failed", err)
+```
+
+Structured options can add context without making the common path noisy:
+
+```go
+sdk.Error(ctx, "Customer import failed", err,
+	sdk.WithTraceID(traceID),
+	sdk.WithReference("crm", "customer", customerID),
+	sdk.WithMetadata("batch", batchName),
+)
+```
+
+Inside hooks and Jobs, dygo should attach context automatically when available:
+
+- source: `hook` or `job`
+- actor: current user when the operation came from a session
+- trace ID: current request or Job trace
+- reference: current Entity and Record when running inside a Record hook
+
+The SDK should also expose a structured form for advanced cases:
+
+```go
+sdk.Log(ctx, sdk.LogEntry{
+	Type:    sdk.LogError,
+	Title:   "Payment sync failed",
+	Error:   err,
+	TraceID: traceID,
+	Metadata: map[string]any{
+		"provider": "stripe",
+		"attempt":  3,
+	},
+})
+```
+
+## Framework Use
+
+dygo should dogfood Logs in framework code.
+
+Good first framework writers:
+
+- recovered panics in HTTP handlers, Jobs, and hooks
+- Job handler failures and retry decisions
+- metadata validation failures at runtime startup
+- Studio API failures that are useful to inspect later
+- secret/config loading failures after redacting sensitive values
+
+Logs must not replace returned errors. A function should still return the correct error to its caller. Logging is additional visibility.
+
+## Studio
+
+Studio should treat Logs as a normal system Entity first:
+
+- list Logs newest-first
+- filter by `type`, `source`, `trace-id`, and reference fields
+- show `error` and `metadata` in readable code-style blocks
+- provide copy buttons for error text, trace ID, and metadata
+
+The screenshot reference from Frappe's Error Log is useful for the detail page shape: top-level reference fields, a short title, a large error/traceback block, trace ID, and structured metadata.
+
+Later Studio can add dedicated Log screens, but the first version should work through the generic metadata-driven Record UI.
+
+## Retention
+
+Logs can grow quickly. The first implementation should plan for retention even if cleanup lands later.
+
+Suggested default retention:
+
+| Type | Default retention |
+| --- | --- |
+| `debug` | 7 days |
+| `info` | 30 days |
+| `warning` | 90 days |
+| `error` | 180 days |
+| `panic` | 365 days |
+
+Retention should eventually connect to the Core retention policy Entity rather than hard-coded cleanup rules.
+
+## Privacy
+
+Logs may contain sensitive data. The SDK and framework writers must avoid storing secrets, password values, session tokens, API keys, raw cookies, or full database URLs.
+
+Rules:
+
+- redact known secret values before writing a Log
+- prefer stable IDs, names, and trace IDs over full payload dumps
+- keep request bodies out of Logs by default
+- treat `metadata` as operator-visible application data, not a private vault
+
+If an error string contains a known secret or database URL, dygo should sanitize it before persistence.
+
+## Boundaries
+
+Logs are not Activity. They are not a compliance-grade Audit Log. They are not a replacement for local development console output.
+
+Logs are persisted operational diagnostics. They should be queryable, filterable, and visible in Studio.
+
+Activity stays focused on human-meaningful Record history.
+
+Audit Log remains a future compliance/security feature with stricter immutability, access rules, and retention requirements.
+
+Local console logging remains useful while developing, especially before the database is available.
+
+## Implementation Order
+
+Recommended first pass:
+
+1. Add Core `log` Entity metadata.
+2. Add the Log values to Core fixtures and permissions so system managers can read Logs.
+3. Add SDK helpers for `Debug`, `Info`, `Warning`, `Error`, and structured `Log`.
+4. Add framework writers for recovered panics and Job failures.
+5. Expose Logs through the generic Record API and Studio list/detail UI.
+6. Add retention cleanup after Core retention policy support exists.
+

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -32,52 +32,76 @@ Proposed fields:
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `type` | `select` | yes | Log type such as `debug`, `info`, `warning`, `error`, or `panic`. |
-| `source` | `select` | yes | Where the Log came from, such as `framework`, `sdk`, `http`, `job`, `hook`, `cli`, `worker`, or `studio`. |
-| `title` | `text` | yes | Short human-facing summary. |
-| `message` | `long-text` | no | Longer explanation or plain text detail. |
-| `error` | `long-text` | no | Error string, stack trace, or traceback text. |
+| `type` | `select` | yes | Log type, matching the common logger idea of severity or level. Stored values should be `Debug`, `Info`, `Warning`, `Error`, and `Panic`. |
+| `source` | `select` | yes | Runtime surface that wrote the Log, such as `framework`, `sdk`, `http`, `job`, `hook`, `cli`, or `studio`. |
+| `title` | `text` | yes | Short human-facing summary. Simple SDK calls should map their message here. |
+| `message` | `long-text` | no | Optional longer body or explanation when the title is not enough. |
+| `error` | `long-text` | no | Error string plus stack trace or traceback text when available. |
 | `trace-id` | `text` | no | Correlation ID shared across request, Job, hook, and nested work. |
 | `reference-entity` | `link` | no | Optional Core Entity reference for the related Record type. |
 | `reference-record-id` | `bigint` | no | Optional internal Record ID for the related Record. |
 | `reference-record-name` | `text` | no | Optional stable Record name for the related Record. |
 | `actor` | `link` | no | Optional User that caused the event. |
-| `metadata` | `json` | no | Structured context that does not deserve first-class fields yet. |
+| `metadata` | `json` | no | Structured attributes, tags, and context that do not deserve first-class fields yet. |
 
-`reference-entity` and `actor` should use `foreign-key: false` so old Logs survive target deletion, the same pattern used by Activity history.
+All Log `link` fields should use `foreign-key: false` so old Logs survive target deletion, the same pattern used by Activity history.
 
-Expected indexes:
+Do not add custom indexes in the first pass. Logs should start with the normal Core Record storage shape, and dygo should add indexes later only after Studio usage shows a repeated access pattern that needs one.
 
-| Index | Fields | Purpose |
-| --- | --- | --- |
-| `by-type-created` | `type`, `created-at` | Filter recent errors, warnings, or info Logs. |
-| `by-source-created` | `source`, `created-at` | Inspect one runtime surface. |
-| `by-trace` | `trace-id` | Follow a request or Job across multiple Logs. |
-| `by-reference` | `reference-entity`, `reference-record-id` | Show Logs related to one Record. |
+## Field Review
+
+Common loggers and observability tools converge on a small set of concepts:
+
+- level or severity
+- message or body
+- timestamp
+- source, logger, scope, or resource
+- error or exception details
+- trace correlation
+- structured attributes, tags, or context
+- user context for application errors
+
+The proposed Log fields cover those concepts without making the Entity too wide:
+
+| Common concept | dygo field |
+| --- | --- |
+| level or severity | `type` |
+| message or body | `title`, optionally `message` |
+| timestamp | Core Record `created-at` |
+| source, logger, scope, or resource | `source`, optionally `metadata` |
+| error, exception, stack trace, or traceback | `error` |
+| trace correlation | `trace-id` |
+| structured attributes, tags, or context | `metadata` |
+| user context | `actor`, optionally `metadata` |
+| related object | `reference-entity`, `reference-record-id`, `reference-record-name` |
+
+Do not add dedicated v1 fields for `span-id`, `environment`, `release`, `logger`, `request-path`, `status-code`, `fingerprint`, or breadcrumbs. Put those in `metadata` until dygo has a clear Studio workflow that needs first-class filtering or display.
 
 ## Types
 
 Initial Log types:
 
 ```txt
-debug
-info
-warning
-error
-panic
+Debug
+Info
+Warning
+Error
+Panic
 ```
 
-`debug` is for local or temporary detail. It should be easy to disable or retain for a shorter time.
+These are the exact select values stored in the database. SDK helpers and constants should map to these title-case values so app code does not need to pass raw strings.
 
-`info` is for useful operational breadcrumbs.
+`Debug` is for local or temporary detail. It should be easy to disable when a writer does not need that level of detail.
 
-`warning` is for recoverable problems that may need attention.
+`Info` is for useful operational breadcrumbs.
 
-`error` is for failed operations.
+`Warning` is for recoverable problems that may need attention.
 
-`panic` is for recovered crashes or unrecoverable code paths that dygo managed to capture.
+`Error` is for failed operations.
 
-The type list can grow later, but v1 should stay small so Studio filters and retention policies remain simple.
+`Panic` is for recovered crashes or unrecoverable code paths that dygo managed to capture.
+
+The type list can grow later, but v1 should stay small so Studio filters remain simple.
 
 ## SDK
 
@@ -86,17 +110,22 @@ The SDK should make writing Logs simple. App code should not need to know the Co
 Intended ergonomic shape:
 
 ```go
-sdk.Info(ctx, "Customer import started")
-sdk.Error(ctx, "Customer import failed", err)
+dygo.Debug(ctx, "Resolved pricing rule")
+dygo.Info(ctx, "Customer import started")
+dygo.Warning(ctx, "Stripe rate limit hit")
+dygo.Error(ctx, "Customer import failed", err)
+dygo.Panic(ctx, "Recovered hook panic", recovered)
 ```
+
+The public package name should be `dygo`, not `sdk`, once the public SDK import path is renamed.
 
 Structured options can add context without making the common path noisy:
 
 ```go
-sdk.Error(ctx, "Customer import failed", err,
-	sdk.WithTraceID(traceID),
-	sdk.WithReference("crm", "customer", customerID),
-	sdk.WithMetadata("batch", batchName),
+dygo.Error(ctx, "Customer import failed", err,
+	dygo.WithTraceID(traceID),
+	dygo.WithReference("crm", "customer", customerID),
+	dygo.WithMetadata("batch", batchName),
 )
 ```
 
@@ -110,8 +139,8 @@ Inside hooks and Jobs, dygo should attach context automatically when available:
 The SDK should also expose a structured form for advanced cases:
 
 ```go
-sdk.Log(ctx, sdk.LogEntry{
-	Type:    sdk.LogError,
+dygo.Log(ctx, dygo.LogEntry{
+	Type:    dygo.TypeError,
 	Title:   "Payment sync failed",
 	Error:   err,
 	TraceID: traceID,
@@ -121,6 +150,18 @@ sdk.Log(ctx, sdk.LogEntry{
 	},
 })
 ```
+
+The structured `LogEntry.Type` constants should be named after the field, not the Entity:
+
+```go
+dygo.TypeDebug
+dygo.TypeInfo
+dygo.TypeWarning
+dygo.TypeError
+dygo.TypePanic
+```
+
+This keeps the common helpers short (`dygo.Error`) while avoiding a Go package namespace conflict with the type constants.
 
 ## Framework Use
 
@@ -149,35 +190,6 @@ The screenshot reference from Frappe's Error Log is useful for the detail page s
 
 Later Studio can add dedicated Log screens, but the first version should work through the generic metadata-driven Record UI.
 
-## Retention
-
-Logs can grow quickly. The first implementation should plan for retention even if cleanup lands later.
-
-Suggested default retention:
-
-| Type | Default retention |
-| --- | --- |
-| `debug` | 7 days |
-| `info` | 30 days |
-| `warning` | 90 days |
-| `error` | 180 days |
-| `panic` | 365 days |
-
-Retention should eventually connect to the Core retention policy Entity rather than hard-coded cleanup rules.
-
-## Privacy
-
-Logs may contain sensitive data. The SDK and framework writers must avoid storing secrets, password values, session tokens, API keys, raw cookies, or full database URLs.
-
-Rules:
-
-- redact known secret values before writing a Log
-- prefer stable IDs, names, and trace IDs over full payload dumps
-- keep request bodies out of Logs by default
-- treat `metadata` as operator-visible application data, not a private vault
-
-If an error string contains a known secret or database URL, dygo should sanitize it before persistence.
-
 ## Boundaries
 
 Logs are not Activity. They are not a compliance-grade Audit Log. They are not a replacement for local development console output.
@@ -186,7 +198,7 @@ Logs are persisted operational diagnostics. They should be queryable, filterable
 
 Activity stays focused on human-meaningful Record history.
 
-Audit Log remains a future compliance/security feature with stricter immutability, access rules, and retention requirements.
+Audit Log remains a future compliance/security feature with stricter immutability, access rules, and lifecycle requirements.
 
 Local console logging remains useful while developing, especially before the database is available.
 
@@ -199,5 +211,3 @@ Recommended first pass:
 3. Add SDK helpers for `Debug`, `Info`, `Warning`, `Error`, and structured `Log`.
 4. Add framework writers for recovered panics and Job failures.
 5. Expose Logs through the generic Record API and Studio list/detail UI.
-6. Add retention cleanup after Core retention policy support exists.
-

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -136,7 +136,7 @@ dygo.Error(ctx, "Customer import failed", err)
 dygo.Panic(ctx, "Recovered hook panic", recovered)
 ```
 
-The public package name should be `dygo`, not `sdk`, once the public SDK import path is renamed.
+The public package name is `dygo`.
 
 The helper functions are best-effort and should not return errors. Logging should add visibility without forcing every app call site into log-persistence error handling.
 
@@ -176,7 +176,7 @@ Inside hooks and Jobs, dygo should attach context automatically when available:
 The SDK should also expose a structured form for advanced cases:
 
 ```go
-err := dygo.Log(ctx, dygo.LogEntry{
+logErr := dygo.Log(ctx, dygo.LogEntry{
 	Type:    dygo.TypeError,
 	Title:   "Payment sync failed",
 	Message: err.Error(),
@@ -249,8 +249,7 @@ Local console logging remains useful while developing, especially before the dat
 
 Recommended first pass:
 
-1. Rename the public SDK package and import path from `pkg/sdk` to `pkg/dygo`, without keeping a compatibility shim.
-2. Add Core `log` Entity metadata.
-3. Add SDK helpers for `Debug`, `Info`, `Warning`, `Error`, and structured `Log`.
-4. Dogfood Logs with recovered panic writers first.
-5. Expose Logs through the generic Record API and Studio list/detail UI.
+1. Add Core `log` Entity metadata.
+2. Add dygo helpers for `Debug`, `Info`, `Warning`, `Error`, and structured `Log`.
+3. Dogfood Logs with recovered panic writers first.
+4. Expose Logs through the generic Record API and Studio list/detail UI.

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -24,7 +24,7 @@ Examples:
 
 ## Log Entity
 
-The Core app owns a system Entity named `log`.
+The Core app owns a system Entity with key `log`, label `Log`, and Studio navigation label `Logs`.
 
 The Entity should be append-only by default. App code and framework code create Logs; normal app workflows should not edit them.
 
@@ -33,10 +33,10 @@ Proposed fields:
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
 | `type` | `select` | yes | Log type, matching the common logger idea of severity or level. Stored values should be `Debug`, `Info`, `Warning`, `Error`, and `Panic`. |
-| `source` | `select` | yes | Runtime surface that wrote the Log, such as `framework`, `sdk`, `http`, `job`, `hook`, `cli`, or `studio`. |
+| `source` | `select` | yes | Runtime surface that wrote the Log. Stored values should be `Framework`, `SDK`, `HTTP`, `Job`, `Hook`, `CLI`, and `Studio`. |
+| `app` | `link` | no | Optional Core App that produced the Log. This should be set explicitly by the SDK or framework when app context is known, not fetched from another field. |
 | `title` | `text` | yes | Short human-facing summary. Simple SDK calls should map their message here. |
-| `message` | `long-text` | no | Optional longer body or explanation when the title is not enough. |
-| `error` | `long-text` | no | Error string plus stack trace or traceback text when available. |
+| `message` | `long-text` | no | Optional full detail for any Log type, including error text, stack traces, tracebacks, success details, or diagnostic notes. |
 | `trace-id` | `text` | no | Correlation ID shared across request, Job, hook, and nested work. |
 | `reference-entity` | `link` | no | Optional Core Entity reference for the related Record type. |
 | `reference-record-id` | `bigint` | no | Optional internal Record ID for the related Record. |
@@ -45,6 +45,8 @@ Proposed fields:
 | `metadata` | `json` | no | Structured attributes, tags, and context that do not deserve first-class fields yet. |
 
 All Log `link` fields should use `foreign-key: false` so old Logs survive target deletion, the same pattern used by Activity history.
+
+Do not use `fetch.from` for `app`. Logs often belong to an app without belonging to a specific Record, and an explicit producer app should not be overwritten by a reference-derived value.
 
 Do not add custom indexes in the first pass. Logs should start with the normal Core Record storage shape, and dygo should add indexes later only after Studio usage shows a repeated access pattern that needs one.
 
@@ -69,10 +71,11 @@ The proposed Log fields cover those concepts without making the Entity too wide:
 | message or body | `title`, optionally `message` |
 | timestamp | Core Record `created-at` |
 | source, logger, scope, or resource | `source`, optionally `metadata` |
-| error, exception, stack trace, or traceback | `error` |
+| error, exception, stack trace, traceback, or longer detail | `message` |
 | trace correlation | `trace-id` |
 | structured attributes, tags, or context | `metadata` |
 | user context | `actor`, optionally `metadata` |
+| producing app | `app` |
 | related object | `reference-entity`, `reference-record-id`, `reference-record-name` |
 
 Do not add dedicated v1 fields for `span-id`, `environment`, `release`, `logger`, `request-path`, `status-code`, `fingerprint`, or breadcrumbs. Put those in `metadata` until dygo has a clear Studio workflow that needs first-class filtering or display.
@@ -103,6 +106,22 @@ These are the exact select values stored in the database. SDK helpers and consta
 
 The type list can grow later, but v1 should stay small so Studio filters remain simple.
 
+## Sources
+
+Initial Log source values:
+
+```txt
+Framework
+SDK
+HTTP
+Job
+Hook
+CLI
+Studio
+```
+
+These are the exact select values stored in the database.
+
 ## SDK
 
 The SDK should make writing Logs simple. App code should not need to know the Core Entity fields or call generic Record APIs directly for common cases.
@@ -119,6 +138,8 @@ dygo.Panic(ctx, "Recovered hook panic", recovered)
 
 The public package name should be `dygo`, not `sdk`, once the public SDK import path is renamed.
 
+The helper functions are best-effort and should not return errors. Logging should add visibility without forcing every app call site into log-persistence error handling.
+
 Structured options can add context without making the common path noisy:
 
 ```go
@@ -129,9 +150,25 @@ dygo.Error(ctx, "Customer import failed", err,
 )
 ```
 
+When a helper is called, dygo should fill the obvious fields from the function and from `ctx`:
+
+| Field | Filled how |
+| --- | --- |
+| `type` | From the helper or `LogEntry.Type`. For example, `dygo.Error` writes `Error`. |
+| `source` | From the current runtime context when available: `Hook`, `Job`, `HTTP`, `CLI`, `Studio`, or `Framework`. Use `SDK` as the fallback for direct SDK calls without a richer source. |
+| `app` | From hook or Job context when app-owned code is running, or from explicit options. |
+| `title` | From the helper title argument or `LogEntry.Title`. |
+| `message` | From error detail, stack or traceback text, explicit message/detail options, or `LogEntry.Message`. `dygo.Error(ctx, title, err)` should write `err.Error()` here when `err` is present. |
+| `trace-id` | From `ctx` when the current request, Job, or hook carries trace context, or from explicit options. The helper should not create a different trace ID per log call. |
+| `reference-entity` | From Record hook context when available, or from explicit options. |
+| `reference-record-id` | From Record hook context when available, or from explicit options. |
+| `reference-record-name` | From the current Record name when available, or from explicit options. |
+| `actor` | From current user/session context when available, or from explicit options. |
+| `metadata` | Only caller-provided structured context or `LogEntry.Metadata`. |
+
 Inside hooks and Jobs, dygo should attach context automatically when available:
 
-- source: `hook` or `job`
+- source: `Hook` or `Job`
 - actor: current user when the operation came from a session
 - trace ID: current request or Job trace
 - reference: current Entity and Record when running inside a Record hook
@@ -139,10 +176,10 @@ Inside hooks and Jobs, dygo should attach context automatically when available:
 The SDK should also expose a structured form for advanced cases:
 
 ```go
-dygo.Log(ctx, dygo.LogEntry{
+err := dygo.Log(ctx, dygo.LogEntry{
 	Type:    dygo.TypeError,
 	Title:   "Payment sync failed",
-	Error:   err,
+	Message: err.Error(),
 	TraceID: traceID,
 	Metadata: map[string]any{
 		"provider": "stripe",
@@ -150,6 +187,8 @@ dygo.Log(ctx, dygo.LogEntry{
 	},
 })
 ```
+
+Unlike the helper functions, `dygo.Log` should return an error so framework code and strict app code can react when Log persistence fails.
 
 The structured `LogEntry.Type` constants should be named after the field, not the Entity:
 
@@ -183,12 +222,16 @@ Studio should treat Logs as a normal system Entity first:
 
 - list Logs newest-first
 - filter by `type`, `source`, `trace-id`, and reference fields
-- show `error` and `metadata` in readable code-style blocks
-- provide copy buttons for error text, trace ID, and metadata
+- show `message` and `metadata` in readable code-style blocks
+- provide copy buttons for message text, trace ID, and metadata
 
-The screenshot reference from Frappe's Error Log is useful for the detail page shape: top-level reference fields, a short title, a large error/traceback block, trace ID, and structured metadata.
+The screenshot reference from Frappe's Error Log is useful for the detail page shape: top-level reference fields, a short title, a large message block for error or diagnostic detail, trace ID, and structured metadata.
 
 Later Studio can add dedicated Log screens, but the first version should work through the generic metadata-driven Record UI.
+
+## Permissions
+
+Do not add Log-specific permissions in v1. Existing admin/system access is enough for the first implementation. Log permissions should be handled later with the broader permissions work.
 
 ## Boundaries
 
@@ -206,8 +249,8 @@ Local console logging remains useful while developing, especially before the dat
 
 Recommended first pass:
 
-1. Add Core `log` Entity metadata.
-2. Add the Log values to Core fixtures and permissions so system managers can read Logs.
+1. Rename the public SDK package and import path from `pkg/sdk` to `pkg/dygo`, without keeping a compatibility shim.
+2. Add Core `log` Entity metadata.
 3. Add SDK helpers for `Debug`, `Info`, `Warning`, `Error`, and structured `Log`.
-4. Add framework writers for recovered panics and Job failures.
+4. Dogfood Logs with recovered panic writers first.
 5. Expose Logs through the generic Record API and Studio list/detail UI.

--- a/docs/record-hooks.md
+++ b/docs/record-hooks.md
@@ -50,19 +50,19 @@ package hooks
 import (
 	"context"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-func Register(registry sdk.RecordHookRegistry) error {
-	return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "normalize-lead", normalizeLead)
+func Register(registry dygo.RecordHookRegistry) error {
+	return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "normalize-lead", normalizeLead)
 }
 
-func normalizeLead(ctx context.Context, hook sdk.RecordHook) error {
+func normalizeLead(ctx context.Context, hook dygo.RecordHook) error {
 	return nil
 }
 ```
 
-The generated project runner imports each Entity hook package and calls dygo through `pkg/sdk/runtime`:
+The generated project runner imports each Entity hook package and calls dygo through `pkg/dygo/runtime`:
 
 ```go
 package main
@@ -75,8 +75,8 @@ import (
 	"syscall"
 
 	crmleadhooks "example.com/my-project/apps/crm/entities/lead"
-	"github.com/hapyco/dygo/pkg/sdk"
-	dygoruntime "github.com/hapyco/dygo/pkg/sdk/runtime"
+	"github.com/hapyco/dygo/pkg/dygo"
+	dygoruntime "github.com/hapyco/dygo/pkg/dygo/runtime"
 )
 
 func main() {
@@ -84,7 +84,7 @@ func main() {
 	defer stop()
 
 	err := dygoruntime.Run(ctx, os.Args[1:], os.Stdin, os.Stdout, os.Stderr, dygoruntime.Options{
-		RecordHooks: []sdk.RecordHookRegistrar{crmleadhooks.Register},
+		RecordHooks: []dygo.RecordHookRegistrar{crmleadhooks.Register},
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -134,7 +134,7 @@ Avoid external side effects in v1 hooks unless they are safe to repeat or compen
 
 App hooks run after framework global hooks for the same Record event.
 
-`dygo dev`, `dygo serve`, and `dygo fixture apply` use the compiled hook registry when run through a project binary built with `pkg/sdk/runtime`.
+`dygo dev`, `dygo serve`, and `dygo fixture apply` use the compiled hook registry when run through a project binary built with `pkg/dygo/runtime`.
 
 The stock `cmd/dygo` binary only includes framework hooks.
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -3,12 +3,12 @@
 The App SDK is the Go package app code compiles against:
 
 ```go
-import "github.com/hapyco/dygo/pkg/sdk"
+import "github.com/hapyco/dygo/pkg/dygo"
 ```
 
-Everything under `internal/` is private framework implementation. App-owned hooks and Jobs should only depend on `pkg/sdk` and normal Go packages.
+Everything under `internal/` is private framework implementation. App-owned hooks and Jobs should only depend on `pkg/dygo` and normal Go packages.
 
-The current supported package is `pkg/sdk`. A shorter `pkg/dygo` import path is coming soon if the public Go API graduates from the current SDK shape.
+The supported public package is `pkg/dygo`.
 
 ## SDK Vs HTTP API
 
@@ -27,6 +27,7 @@ The current SDK exposes:
 - transactional Record reads and writes inside hooks
 - durable Job handler types and registration
 - Job enqueueing from hooks and Jobs
+- best-effort and strict persisted Log helpers
 - project runner integration types
 
 ## Record Hooks
@@ -34,11 +35,11 @@ The current SDK exposes:
 Record hooks register functions for Entity lifecycle events:
 
 ```go
-func Register(registry sdk.RecordHookRegistry) error {
-	return registry.RegisterEntity("crm", "contact", sdk.RecordAfterCreate, "send-welcome", SendWelcome)
+func Register(registry dygo.RecordHookRegistry) error {
+	return registry.RegisterEntity("crm", "contact", dygo.RecordAfterCreate, "send-welcome", SendWelcome)
 }
 
-func SendWelcome(ctx context.Context, hook sdk.RecordHook) error {
+func SendWelcome(ctx context.Context, hook dygo.RecordHook) error {
 	return nil
 }
 ```
@@ -56,7 +57,7 @@ before-delete
 after-delete
 ```
 
-Hooks receive `sdk.RecordHook`, which includes the Entity identity, current input, old/new Record snapshots, changes, and SDK services.
+Hooks receive `dygo.RecordHook`, which includes the Entity identity, current input, old/new Record snapshots, changes, and SDK services.
 
 ## Record Access
 
@@ -64,10 +65,10 @@ Hooks read and write metadata-backed Records through `hook.Records`:
 
 ```go
 record, err := hook.Records.Get(ctx, "crm", "contact", 42)
-created, err := hook.Records.Create(ctx, "crm", "activity", sdk.RecordInput{
+created, err := hook.Records.Create(ctx, "crm", "activity", dygo.RecordInput{
 	"subject": json.RawMessage(`"Welcome"`),
 })
-updated, err := hook.Records.Update(ctx, "crm", "contact", 42, sdk.RecordInput{
+updated, err := hook.Records.Update(ctx, "crm", "contact", 42, dygo.RecordInput{
 	"status": json.RawMessage(`"Active"`),
 })
 err := hook.Records.Delete(ctx, "crm", "contact", 42)
@@ -88,7 +89,7 @@ Hook Record writes run dygo framework hooks, such as Activity, but do not re-ent
 Generated Job files expose one `Run` function:
 
 ```go
-func Run(ctx context.Context, job sdk.JobExecution) error {
+func Run(ctx context.Context, job dygo.JobExecution) error {
 	return nil
 }
 ```
@@ -96,7 +97,7 @@ func Run(ctx context.Context, job sdk.JobExecution) error {
 Job handlers and transactional Record hooks can enqueue durable background work:
 
 ```go
-execution, err := job.Jobs.Enqueue(ctx, "crm", "send-welcome-email", payload, sdk.EnqueueOptions{
+execution, err := job.Jobs.Enqueue(ctx, "crm", "send-welcome-email", payload, dygo.EnqueueOptions{
 	IdempotencyKey: "email:welcome:contact-42",
 	Priority:       0,
 	RunAfter:       time.Now().Add(10 * time.Minute),
@@ -112,6 +113,17 @@ Job access uses app-scoped Job identity:
 ```
 
 Do not use labels or routes as SDK Job identity.
+
+## Logs
+
+App code can write persisted diagnostic Logs through package helpers:
+
+```go
+dygo.Info(ctx, "Customer import started")
+dygo.Error(ctx, "Customer import failed", err)
+```
+
+The helper functions are best-effort. Use `dygo.Log(ctx, dygo.LogEntry{...})` when code needs to handle persistence errors. See [Logs](logs.md) for the Log Entity contract and field mapping.
 
 ## Runtime Rules
 
@@ -130,7 +142,6 @@ Planned SDK surfaces include:
 dygo.Files         - public/private file storage
 dygo.Permissions   - permission checks
 dygo.Actor         - current user/session identity
-dygo.Logger        - structured app logging
 dygo.Config        - app/runtime config reads
 dygo.Secrets       - controlled secret reads
 dygo.Metadata      - Entity and Field metadata reads

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,6 +12,9 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #7 Add project documentation links
 - [ ] #21 Split field type registry files by responsibility
 - [ ] #24 Add role inheritance for hierarchical permissions
+- [ ] Document fixture-first permission setup for app roles and Entity grants
+- [ ] Remove stale `permissions.yml` references until a dedicated loader exists
+- [ ] Add permission fixture scaffolding when generating new app Entities
 - [x] #31 Add worker command
 - [x] #32 Add scheduler behavior to workers
 - [ ] #33 Add site command group

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,6 +11,7 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #5 Create the opinions directory
 - [ ] #7 Add project documentation links
 - [ ] #21 Split field type registry files by responsibility
+- [ ] Rename Entity metadata files from `entity.yml` to `<entity>.entity.yml` in one repo-wide pass
 - [ ] #24 Add role inheritance for hierarchical permissions
 - [ ] Document fixture-first permission setup for app roles and Entity grants
 - [ ] Remove stale `permissions.yml` references until a dedicated loader exists

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,11 +11,11 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #5 Create the opinions directory
 - [ ] #7 Add project documentation links
 - [ ] #21 Split field type registry files by responsibility
-- [ ] Rename Entity metadata files from `entity.yml` to `<entity>.entity.yml` in one repo-wide pass
+- [ ] #242 Rename Entity metadata files from `entity.yml` to `<entity>.entity.yml` in one repo-wide pass
 - [ ] #24 Add role inheritance for hierarchical permissions
-- [ ] Document fixture-first permission setup for app roles and Entity grants
-- [ ] Remove stale `permissions.yml` references until a dedicated loader exists
-- [ ] Add permission fixture scaffolding when generating new app Entities
+- [ ] #243 Document fixture-first permission setup for app roles and Entity grants
+- [ ] #244 Remove stale `permissions.yml` references until a dedicated loader exists
+- [ ] #245 Add permission fixture scaffolding when generating new app Entities
 - [x] #31 Add worker command
 - [x] #32 Add scheduler behavior to workers
 - [ ] #33 Add site command group

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -106,9 +106,9 @@ func TestGenerateEntityForcePreservesExistingHookFile(t *testing.T) {
 	hookPath := filepath.Join(root, "apps", "sales", "entities", "lead", "hooks.go")
 	existing := `package hooks
 
-import "github.com/hapyco/dygo/pkg/sdk"
+import "github.com/hapyco/dygo/pkg/dygo"
 
-func Register(registry sdk.RecordHookRegistry) error {
+func Register(registry dygo.RecordHookRegistry) error {
 	return nil
 }
 `

--- a/internal/cli/hooks_test.go
+++ b/internal/cli/hooks_test.go
@@ -114,9 +114,9 @@ fields:
 
 package hooks
 
-import "github.com/hapyco/dygo/pkg/sdk"
+import "github.com/hapyco/dygo/pkg/dygo"
 
-func Register(registry sdk.RecordHookRegistry) error { return nil }
+func Register(registry dygo.RecordHookRegistry) error { return nil }
 `
 	if err := os.WriteFile(hookPath, []byte(generatedHook), 0o644); err != nil {
 		t.Fatalf("WriteFile(hooks.go) error = %v", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hapyco/dygo/internal/server"
 	"github.com/hapyco/dygo/internal/shape"
 	"github.com/hapyco/dygo/internal/studio"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 	"github.com/spf13/cobra"
 )
 
@@ -59,8 +59,8 @@ type schemaSyncRunner interface {
 
 // Options configures dygo CLI runtime extensions.
 type Options struct {
-	RecordHooks []sdk.RecordHookRegistrar
-	Jobs        []sdk.JobRegistrar
+	RecordHooks []dygo.RecordHookRegistrar
+	Jobs        []dygo.JobRegistrar
 }
 
 var startStudioDevServer = startStudioDevServerProcess

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hapyco/dygo/internal/server"
 	"github.com/hapyco/dygo/internal/shape"
 	"github.com/hapyco/dygo/internal/studio"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -683,10 +683,10 @@ func TestRunWithOptionsPassesRecordHooksToServe(t *testing.T) {
 		gotOptions = options
 		return nil
 	}, Options{
-		RecordHooks: []sdk.RecordHookRegistrar{
-			func(registry sdk.RecordHookRegistry) error {
+		RecordHooks: []dygo.RecordHookRegistrar{
+			func(registry dygo.RecordHookRegistry) error {
 				registrarCalled = true
-				return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "test", func(context.Context, sdk.RecordHook) error {
+				return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "test", func(context.Context, dygo.RecordHook) error {
 					return nil
 				})
 			},
@@ -1632,10 +1632,10 @@ timeout: 30s
 import (
 	"context"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-func Run(ctx context.Context, job sdk.JobExecution) error {
+func Run(ctx context.Context, job dygo.JobExecution) error {
 	return nil
 }
 `), 0o644); err != nil {
@@ -2626,7 +2626,7 @@ func runWithOptionsForTest(ctx context.Context, args []string, stdin io.Reader, 
 	return runWithServicesAndSetupAndFixturesAndHooks(ctx, args, stdin, stdout, stderr, serve, noopDatabaseRunner(), migrator, &fakeAdminSetupRunner{}, &fakeFixtureRunner{}, &fakePermissionRunner{}, recordHooks, jobRegistry)
 }
 
-func recordhooksForTest(registrars []sdk.RecordHookRegistrar) (*db.RecordHookRegistry, error) {
+func recordhooksForTest(registrars []dygo.RecordHookRegistrar) (*db.RecordHookRegistry, error) {
 	return recordhooks.NewRecordHookRegistry(registrars)
 }
 

--- a/internal/corevalues/values.go
+++ b/internal/corevalues/values.go
@@ -107,3 +107,45 @@ func ActivityStatuses() []string {
 		ActivityStatusFailed,
 	}
 }
+
+const (
+	LogTypeDebug   = "Debug"
+	LogTypeInfo    = "Info"
+	LogTypeWarning = "Warning"
+	LogTypeError   = "Error"
+	LogTypePanic   = "Panic"
+)
+
+// LogTypes returns Core log type values in metadata order.
+func LogTypes() []string {
+	return []string{
+		LogTypeDebug,
+		LogTypeInfo,
+		LogTypeWarning,
+		LogTypeError,
+		LogTypePanic,
+	}
+}
+
+const (
+	LogSourceFramework = "Framework"
+	LogSourceSDK       = "SDK"
+	LogSourceHTTP      = "HTTP"
+	LogSourceJob       = "Job"
+	LogSourceHook      = "Hook"
+	LogSourceCLI       = "CLI"
+	LogSourceStudio    = "Studio"
+)
+
+// LogSources returns Core log source values in metadata order.
+func LogSources() []string {
+	return []string{
+		LogSourceFramework,
+		LogSourceSDK,
+		LogSourceHTTP,
+		LogSourceJob,
+		LogSourceHook,
+		LogSourceCLI,
+		LogSourceStudio,
+	}
+}

--- a/internal/corevalues/values_test.go
+++ b/internal/corevalues/values_test.go
@@ -22,6 +22,8 @@ func TestCoreSelectValuesMatchEntityMetadata(t *testing.T) {
 		{entity: "activity", field: "kind", want: ActivityKinds()},
 		{entity: "activity", field: "operation", want: ActivityOperations()},
 		{entity: "activity", field: "status", want: ActivityStatuses()},
+		{entity: "log", field: "type", want: LogTypes()},
+		{entity: "log", field: "source", want: LogSources()},
 	}
 
 	for _, tt := range tests {

--- a/internal/db/record_hooks.go
+++ b/internal/db/record_hooks.go
@@ -46,6 +46,8 @@ type RecordHookContext struct {
 
 	// Queryer is the current mutation queryer, usually the active transaction.
 	Queryer RecordQueryer
+	// LogQueryer writes diagnostic Logs outside the current mutation transaction.
+	LogQueryer RecordQueryer
 }
 
 // RecordHookRegistry stores global and Entity-scoped Record lifecycle hooks.

--- a/internal/db/records.go
+++ b/internal/db/records.go
@@ -49,6 +49,7 @@ type RecordQueryer interface {
 // RecordStore reads and mutates Records through persisted Entity metadata.
 type RecordStore struct {
 	queryer              RecordQueryer
+	logQueryer           RecordQueryer
 	metadata             MetadataReader
 	hooks                *RecordHookRegistry
 	allowSystemMutations bool
@@ -132,7 +133,7 @@ func NewRecordStoreWithHookPolicy(queryer RecordQueryer, policy RecordMutationHo
 
 // NewRecordStoreWithHooks returns a Record store backed by queryer and hooks.
 func NewRecordStoreWithHooks(queryer RecordQueryer, hooks *RecordHookRegistry) RecordStore {
-	return RecordStore{queryer: queryer, metadata: NewMetadataReader(queryer), hooks: hooks}
+	return RecordStore{queryer: queryer, logQueryer: queryer, metadata: NewMetadataReader(queryer), hooks: hooks}
 }
 
 // ListRecords returns one deterministic page of Records for entity.
@@ -861,6 +862,7 @@ func (s RecordStore) runRecordHooks(ctx context.Context, hookCtx RecordHookConte
 		return nil
 	}
 	hookCtx.Queryer = s.queryer
+	hookCtx.LogQueryer = s.logQueryer
 	return s.hooks.Run(ctx, hookCtx)
 }
 

--- a/internal/db/records_activity.go
+++ b/internal/db/records_activity.go
@@ -85,6 +85,7 @@ func (s RecordStore) withRecordMutation(ctx context.Context, fn func(RecordStore
 	}
 	txStore := NewRecordStoreWithHooks(tx, s.hooks)
 	txStore.allowSystemMutations = s.allowSystemMutations
+	txStore.logQueryer = s.logQueryer
 	record, err := fn(txStore)
 	if err != nil {
 		_ = tx.Rollback(ctx)

--- a/internal/db/records_test.go
+++ b/internal/db/records_test.go
@@ -1566,6 +1566,37 @@ func TestRecordStoreHookErrorPreventsMutation(t *testing.T) {
 	}
 }
 
+func TestRecordStoreHookLogQueryerStaysOutsideMutationTransaction(t *testing.T) {
+	queryer := newUserRecordQueryer()
+	transactional := &fakeTransactionalRecordQueryer{fakeRecordQueryer: queryer}
+	registry := NewRecordHookRegistry()
+	var hookQueryer RecordQueryer
+	var hookLogQueryer RecordQueryer
+	mustRegisterRecordHook(registry.RegisterEntity("core", "user", RecordBeforeCreate, "observe-queryers", func(_ context.Context, hookCtx RecordHookContext) error {
+		hookQueryer = hookCtx.Queryer
+		hookLogQueryer = hookCtx.LogQueryer
+		return errors.New("blocked by test hook")
+	}))
+
+	_, err := NewRecordStoreWithHooks(transactional, registry).CreateRecord(context.Background(), "user", recordInput(map[string]string{
+		"email":     `"a@example.com"`,
+		"full-name": `"A User"`,
+	}))
+	assertRecordError(t, err, RecordErrorValidation, "")
+	if transactional.tx == nil {
+		t.Fatal("transaction was not opened")
+	}
+	if !transactional.tx.rolledBack {
+		t.Fatal("transaction rolledBack = false, want rollback after hook error")
+	}
+	if hookQueryer != transactional.tx {
+		t.Fatalf("hook Queryer = %T, want active transaction %T", hookQueryer, transactional.tx)
+	}
+	if hookLogQueryer != transactional {
+		t.Fatalf("hook LogQueryer = %T, want outer queryer %T", hookLogQueryer, transactional)
+	}
+}
+
 func TestRecordStoreValidationErrors(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/dygodata/jobs.go
+++ b/internal/dygodata/jobs.go
@@ -1,11 +1,11 @@
-package sdkdata
+package dygodata
 
 import (
 	"context"
 	"encoding/json"
 
 	jobstore "github.com/hapyco/dygo/internal/jobs/store"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 type jobEnqueuer interface {
@@ -17,12 +17,12 @@ type JobData struct {
 	store jobEnqueuer
 }
 
-// NewJobData returns SDK JobData backed by a durable Job store.
+// NewJobData returns dygo JobData backed by a durable Job store.
 func NewJobData(store jobEnqueuer) JobData {
 	return JobData{store: store}
 }
 
-// NewJobDataFromBeginner returns SDK JobData backed by the current transaction or pool.
+// NewJobDataFromBeginner returns dygo JobData backed by the current transaction or pool.
 func NewJobDataFromBeginner(beginner jobstore.Beginner) (JobData, error) {
 	store, err := jobstore.New(beginner)
 	if err != nil {
@@ -32,16 +32,16 @@ func NewJobDataFromBeginner(beginner jobstore.Beginner) (JobData, error) {
 }
 
 // Enqueue creates one durable Job Execution.
-func (d JobData) Enqueue(ctx context.Context, appName string, jobName string, payload json.RawMessage, options sdk.EnqueueOptions) (sdk.JobExecution, error) {
+func (d JobData) Enqueue(ctx context.Context, appName string, jobName string, payload json.RawMessage, options dygo.EnqueueOptions) (dygo.JobExecution, error) {
 	execution, err := d.store.Enqueue(ctx, appName, jobName, payload, jobstore.EnqueueOptions{
 		IdempotencyKey: options.IdempotencyKey,
 		Priority:       options.Priority,
 		RunAfter:       options.RunAfter,
 	})
 	if err != nil {
-		return sdk.JobExecution{}, err
+		return dygo.JobExecution{}, err
 	}
-	return sdk.JobExecution{
+	return dygo.JobExecution{
 		ID:      execution.ID,
 		AppName: execution.AppName,
 		JobName: execution.JobName,

--- a/internal/dygodata/jobs_test.go
+++ b/internal/dygodata/jobs_test.go
@@ -1,4 +1,4 @@
-package sdkdata
+package dygodata
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	jobstore "github.com/hapyco/dygo/internal/jobs/store"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 func TestJobDataEnqueueMapsSDKOptions(t *testing.T) {
@@ -23,7 +23,7 @@ func TestJobDataEnqueueMapsSDKOptions(t *testing.T) {
 		},
 	}
 
-	execution, err := NewJobData(store).Enqueue(context.Background(), "crm", "send-email", json.RawMessage(`{"email":"a@example.com"}`), sdk.EnqueueOptions{
+	execution, err := NewJobData(store).Enqueue(context.Background(), "crm", "send-email", json.RawMessage(`{"email":"a@example.com"}`), dygo.EnqueueOptions{
 		IdempotencyKey: "email:1",
 		Priority:       10,
 		RunAfter:       runAfter,

--- a/internal/dygodata/logs.go
+++ b/internal/dygodata/logs.go
@@ -1,0 +1,75 @@
+package dygodata
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+// LogData persists dygo Log entries through Core Records.
+type LogData struct {
+	writer db.SystemRecordWriter
+}
+
+// NewLogData returns LogData backed by metadata-driven Record storage.
+func NewLogData(queryer db.RecordQueryer) LogData {
+	return LogData{writer: db.NewSystemRecordWriter(queryer)}
+}
+
+// WriteLog persists one LogEntry without running Record hooks or writing Activity.
+func (d LogData) WriteLog(ctx context.Context, entry dygo.LogEntry) error {
+	input, err := logInput(entry)
+	if err != nil {
+		return err
+	}
+	return d.writer.InsertByIdentity(ctx, "core", "log", input, db.SystemMutationSilent)
+}
+
+func logInput(entry dygo.LogEntry) (db.RecordInput, error) {
+	input := db.RecordInput{
+		"type":   logString(string(entry.Type)),
+		"source": logString(string(entry.Source)),
+		"title":  logString(entry.Title),
+	}
+	if value := strings.TrimSpace(entry.App); value != "" {
+		input["app"] = logString(value)
+	}
+	if value := strings.TrimSpace(entry.Message); value != "" {
+		input["message"] = logString(value)
+	}
+	if value := strings.TrimSpace(entry.TraceID); value != "" {
+		input["trace-id"] = logString(value)
+	}
+	if value := strings.TrimSpace(entry.ReferenceEntity); value != "" {
+		input["reference-entity"] = logString(value)
+	}
+	if entry.ReferenceRecordID != 0 {
+		input["reference-record-id"] = logInt(entry.ReferenceRecordID)
+	}
+	if value := strings.TrimSpace(entry.ReferenceRecordName); value != "" {
+		input["reference-record-name"] = logString(value)
+	}
+	if value := strings.TrimSpace(entry.Actor); value != "" {
+		input["actor"] = logString(value)
+	}
+	if len(entry.Metadata) > 0 {
+		metadata, err := json.Marshal(entry.Metadata)
+		if err != nil {
+			return nil, err
+		}
+		input["metadata"] = metadata
+	}
+	return input, nil
+}
+
+func logString(value string) json.RawMessage {
+	return json.RawMessage(strconv.Quote(value))
+}
+
+func logInt(value int64) json.RawMessage {
+	return json.RawMessage(strconv.FormatInt(value, 10))
+}

--- a/internal/dygodata/logs.go
+++ b/internal/dygodata/logs.go
@@ -67,7 +67,11 @@ func logInput(entry dygo.LogEntry) (db.RecordInput, error) {
 }
 
 func logString(value string) json.RawMessage {
-	return json.RawMessage(strconv.Quote(value))
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage(`""`)
+	}
+	return encoded
 }
 
 func logInt(value int64) json.RawMessage {

--- a/internal/dygodata/logs_test.go
+++ b/internal/dygodata/logs_test.go
@@ -1,0 +1,52 @@
+package dygodata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+func TestLogInputMapsEntryToCoreRecordInput(t *testing.T) {
+	input, err := logInput(dygo.LogEntry{
+		Type:                dygo.TypeError,
+		Source:              dygo.SourceHook,
+		App:                 "crm",
+		Title:               "Customer import failed",
+		Message:             "stripe timeout",
+		TraceID:             "trace-1",
+		ReferenceEntity:     "crm.customer",
+		ReferenceRecordID:   42,
+		ReferenceRecordName: "CUST-42",
+		Actor:               "admin@example.com",
+		Metadata:            map[string]any{"batch": "May"},
+	})
+	if err != nil {
+		t.Fatalf("logInput() error = %v, want nil", err)
+	}
+
+	for key, want := range map[string]string{
+		"type":                  `"Error"`,
+		"source":                `"Hook"`,
+		"app":                   `"crm"`,
+		"title":                 `"Customer import failed"`,
+		"message":               `"stripe timeout"`,
+		"trace-id":              `"trace-1"`,
+		"reference-entity":      `"crm.customer"`,
+		"reference-record-name": `"CUST-42"`,
+		"actor":                 `"admin@example.com"`,
+		"reference-record-id":   `42`,
+	} {
+		if got := string(input[key]); got != want {
+			t.Fatalf("input[%q] = %s, want %s", key, got, want)
+		}
+	}
+
+	var metadata map[string]any
+	if err := json.Unmarshal(input["metadata"], &metadata); err != nil {
+		t.Fatalf("metadata decode error = %v", err)
+	}
+	if metadata["batch"] != "May" {
+		t.Fatalf("metadata = %#v, want batch", metadata)
+	}
+}

--- a/internal/dygodata/logs_test.go
+++ b/internal/dygodata/logs_test.go
@@ -50,3 +50,31 @@ func TestLogInputMapsEntryToCoreRecordInput(t *testing.T) {
 		t.Fatalf("metadata = %#v, want batch", metadata)
 	}
 }
+
+func TestLogInputEncodesStringsAsJSON(t *testing.T) {
+	title := "\x1b[31mCustomer import failed\x1b[0m"
+	message := "line one\nline two"
+
+	input, err := logInput(dygo.LogEntry{
+		Type:    dygo.TypeError,
+		Source:  dygo.SourceHook,
+		Title:   title,
+		Message: message,
+	})
+	if err != nil {
+		t.Fatalf("logInput() error = %v, want nil", err)
+	}
+
+	for key, want := range map[string]string{
+		"title":   title,
+		"message": message,
+	} {
+		var got string
+		if err := json.Unmarshal(input[key], &got); err != nil {
+			t.Fatalf("input[%q] decode error = %v", key, err)
+		}
+		if got != want {
+			t.Fatalf("input[%q] = %q, want %q", key, got, want)
+		}
+	}
+}

--- a/internal/dygodata/records.go
+++ b/internal/dygodata/records.go
@@ -1,11 +1,11 @@
-// Package sdkdata adapts internal runtime services to public SDK interfaces.
-package sdkdata
+// Package dygodata adapts internal runtime services to public dygo interfaces.
+package dygodata
 
 import (
 	"context"
 
 	"github.com/hapyco/dygo/internal/db"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 // RecordData exposes metadata-backed Record access through the public SDK.
@@ -15,12 +15,12 @@ type RecordData struct {
 	mutationHooks db.RecordMutationHookPolicy
 }
 
-// NewRecordData returns SDK RecordData that uses the supplied Record hooks.
+// NewRecordData returns dygo RecordData that uses the supplied Record hooks.
 func NewRecordData(queryer db.RecordQueryer, hooks *db.RecordHookRegistry) RecordData {
 	return RecordData{queryer: queryer, hooks: hooks, mutationHooks: db.RecordMutationHooksFrameworkOnly}
 }
 
-// NewRecordDataWithHookPolicy returns SDK RecordData with an explicit mutation hook policy.
+// NewRecordDataWithHookPolicy returns dygo RecordData with an explicit mutation hook policy.
 func NewRecordDataWithHookPolicy(queryer db.RecordQueryer, policy db.RecordMutationHookPolicy) RecordData {
 	return RecordData{queryer: queryer, mutationHooks: policy}
 }
@@ -33,20 +33,20 @@ func (d RecordData) store() db.RecordStore {
 }
 
 // List returns a page of Records by app/entity identity.
-func (d RecordData) List(ctx context.Context, appName string, entity string, params sdk.RecordListParams) (sdk.RecordListResult, error) {
+func (d RecordData) List(ctx context.Context, appName string, entity string, params dygo.RecordListParams) (dygo.RecordListResult, error) {
 	result, err := d.store().ListRecordsByIdentity(ctx, appName, entity, dbRecordListParams(params))
 	if err != nil {
-		return sdk.RecordListResult{}, err
+		return dygo.RecordListResult{}, err
 	}
-	return sdk.RecordListResult{
-		Records: sdkRecords(result.Records),
+	return dygo.RecordListResult{
+		Records: dygoRecords(result.Records),
 		Limit:   result.Limit,
 		Offset:  result.Offset,
 		Count:   result.Count,
 	}, nil
 }
 
-func dbRecordListParams(params sdk.RecordListParams) db.RecordListParams {
+func dbRecordListParams(params dygo.RecordListParams) db.RecordListParams {
 	converted := db.RecordListParams{
 		Limit:  params.Limit,
 		Offset: params.Offset,
@@ -67,39 +67,39 @@ func dbRecordListParams(params sdk.RecordListParams) db.RecordListParams {
 }
 
 // Get returns one Record by app/entity identity and row ID.
-func (d RecordData) Get(ctx context.Context, appName string, entity string, id int64) (sdk.Record, error) {
+func (d RecordData) Get(ctx context.Context, appName string, entity string, id int64) (dygo.Record, error) {
 	record, err := d.store().GetRecordByIdentity(ctx, appName, entity, id)
 	if err != nil {
 		return nil, err
 	}
-	return sdk.Record(record), nil
+	return dygo.Record(record), nil
 }
 
 // Find returns one Record matching metadata-backed fields.
-func (d RecordData) Find(ctx context.Context, appName string, entity string, match sdk.RecordInput) (sdk.Record, error) {
+func (d RecordData) Find(ctx context.Context, appName string, entity string, match dygo.RecordInput) (dygo.Record, error) {
 	record, err := d.store().FindRecordByIdentity(ctx, appName, entity, db.RecordInput(match))
 	if err != nil {
 		return nil, err
 	}
-	return sdk.Record(record), nil
+	return dygo.Record(record), nil
 }
 
 // Create creates one Record by app/entity identity.
-func (d RecordData) Create(ctx context.Context, appName string, entity string, input sdk.RecordInput) (sdk.Record, error) {
+func (d RecordData) Create(ctx context.Context, appName string, entity string, input dygo.RecordInput) (dygo.Record, error) {
 	record, err := d.store().CreateRecordByIdentity(ctx, appName, entity, db.RecordInput(input))
 	if err != nil {
 		return nil, err
 	}
-	return sdk.Record(record), nil
+	return dygo.Record(record), nil
 }
 
 // Update updates one Record by app/entity identity and row ID.
-func (d RecordData) Update(ctx context.Context, appName string, entity string, id int64, input sdk.RecordInput) (sdk.Record, error) {
+func (d RecordData) Update(ctx context.Context, appName string, entity string, id int64, input dygo.RecordInput) (dygo.Record, error) {
 	record, err := d.store().UpdateRecordByIdentity(ctx, appName, entity, id, db.RecordInput(input))
 	if err != nil {
 		return nil, err
 	}
-	return sdk.Record(record), nil
+	return dygo.Record(record), nil
 }
 
 // Delete deletes one Record by app/entity identity and row ID.
@@ -107,10 +107,10 @@ func (d RecordData) Delete(ctx context.Context, appName string, entity string, i
 	return d.store().DeleteRecordByIdentity(ctx, appName, entity, id)
 }
 
-func sdkRecords(records []db.Record) []sdk.Record {
-	converted := make([]sdk.Record, len(records))
+func dygoRecords(records []db.Record) []dygo.Record {
+	converted := make([]dygo.Record, len(records))
 	for i, record := range records {
-		converted[i] = sdk.Record(record)
+		converted[i] = dygo.Record(record)
 	}
 	return converted
 }

--- a/internal/entity/catalog/repository_test.go
+++ b/internal/entity/catalog/repository_test.go
@@ -44,6 +44,7 @@ func TestRepositoryEntitiesValidate(t *testing.T) {
 		"job",
 		"job-execution",
 		"language",
+		"log",
 		"naming-series",
 		"patch-run",
 		"permission",

--- a/internal/hookgen/hookgen.go
+++ b/internal/hookgen/hookgen.go
@@ -102,7 +102,7 @@ func GenerateWithOptions(options GenerateOptions) (Result, error) {
 	if exists, hasRegister, err := runnergen.InspectFunctionFile(hookFile, "Register"); err != nil {
 		return Result{}, err
 	} else if exists && !hasRegister {
-		return Result{}, fmt.Errorf("%s exists but does not expose Register(registry sdk.RecordHookRegistry) error", hookFile)
+		return Result{}, fmt.Errorf("%s exists but does not expose Register(registry dygo.RecordHookRegistry) error", hookFile)
 	}
 	if err := runnergen.PreflightGeneratedFile(runnerFile, runnergen.HookManualSnippet(root, modulePath, appName, entityName, entityDir)); err != nil {
 		return Result{}, err
@@ -188,7 +188,7 @@ func Validate(root string) ([]string, error) {
 	var problems []string
 	for _, hook := range hookFiles {
 		if !hook.HasRegister {
-			problems = append(problems, fmt.Sprintf("%s: hook file must expose Register(registry sdk.RecordHookRegistry) error", filepath.ToSlash(hook.Path)))
+			problems = append(problems, fmt.Sprintf("%s: hook file must expose Register(registry dygo.RecordHookRegistry) error", filepath.ToSlash(hook.Path)))
 		}
 	}
 	jobFiles, err := runnergen.DiscoverJobs(root)
@@ -197,7 +197,7 @@ func Validate(root string) ([]string, error) {
 	}
 	for _, job := range jobFiles {
 		if !job.HasRun {
-			problems = append(problems, fmt.Sprintf("%s: job runner file must expose Run(ctx context.Context, job sdk.JobExecution) error", filepath.ToSlash(job.Path)))
+			problems = append(problems, fmt.Sprintf("%s: job runner file must expose Run(ctx context.Context, job dygo.JobExecution) error", filepath.ToSlash(job.Path)))
 		}
 	}
 	update, err := RenderRunner(root)
@@ -286,38 +286,38 @@ func renderEntityHookSource(appName string, entityName string) ([]byte, error) {
 import (
 	"context"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-func Register(registry sdk.RecordHookRegistry) error {
-	if err := registry.RegisterEntity(%[2]q, %[3]q, sdk.RecordBeforeCreate, %[4]q, beforeCreate%[1]s); err != nil {
+func Register(registry dygo.RecordHookRegistry) error {
+	if err := registry.RegisterEntity(%[2]q, %[3]q, dygo.RecordBeforeCreate, %[4]q, beforeCreate%[1]s); err != nil {
 		return err
 	}
-	if err := registry.RegisterEntity(%[2]q, %[3]q, sdk.RecordAfterCreate, %[5]q, afterCreate%[1]s); err != nil {
+	if err := registry.RegisterEntity(%[2]q, %[3]q, dygo.RecordAfterCreate, %[5]q, afterCreate%[1]s); err != nil {
 		return err
 	}
-	if err := registry.RegisterEntity(%[2]q, %[3]q, sdk.RecordBeforeUpdate, %[6]q, beforeUpdate%[1]s); err != nil {
+	if err := registry.RegisterEntity(%[2]q, %[3]q, dygo.RecordBeforeUpdate, %[6]q, beforeUpdate%[1]s); err != nil {
 		return err
 	}
-	if err := registry.RegisterEntity(%[2]q, %[3]q, sdk.RecordAfterUpdate, %[7]q, afterUpdate%[1]s); err != nil {
+	if err := registry.RegisterEntity(%[2]q, %[3]q, dygo.RecordAfterUpdate, %[7]q, afterUpdate%[1]s); err != nil {
 		return err
 	}
 	return nil
 }
 
-func beforeCreate%[1]s(ctx context.Context, dygo sdk.RecordHook) error {
+func beforeCreate%[1]s(ctx context.Context, hook dygo.RecordHook) error {
 	return nil
 }
 
-func afterCreate%[1]s(ctx context.Context, dygo sdk.RecordHook) error {
+func afterCreate%[1]s(ctx context.Context, hook dygo.RecordHook) error {
 	return nil
 }
 
-func beforeUpdate%[1]s(ctx context.Context, dygo sdk.RecordHook) error {
+func beforeUpdate%[1]s(ctx context.Context, hook dygo.RecordHook) error {
 	return nil
 }
 
-func afterUpdate%[1]s(ctx context.Context, dygo sdk.RecordHook) error {
+func afterUpdate%[1]s(ctx context.Context, hook dygo.RecordHook) error {
 	return nil
 }
 `, name, appName, entityName, entityName+"-before-create", entityName+"-after-create", entityName+"-before-update", entityName+"-after-update")

--- a/internal/hookgen/hookgen_test.go
+++ b/internal/hookgen/hookgen_test.go
@@ -29,15 +29,15 @@ func TestGenerateCreatesHookRegisterAndRunner(t *testing.T) {
 		t.Fatalf("hook source = %q, want developer-owned starter without generated ownership header", hookSource)
 	}
 	for _, want := range []string{
-		"func Register(registry sdk.RecordHookRegistry) error",
-		`sdk.RecordBeforeCreate, "lead-before-create", beforeCreateLead`,
-		`sdk.RecordAfterCreate, "lead-after-create", afterCreateLead`,
-		`sdk.RecordBeforeUpdate, "lead-before-update", beforeUpdateLead`,
-		`sdk.RecordAfterUpdate, "lead-after-update", afterUpdateLead`,
-		"func beforeCreateLead(ctx context.Context, dygo sdk.RecordHook) error",
-		"func afterCreateLead(ctx context.Context, dygo sdk.RecordHook) error",
-		"func beforeUpdateLead(ctx context.Context, dygo sdk.RecordHook) error",
-		"func afterUpdateLead(ctx context.Context, dygo sdk.RecordHook) error",
+		"func Register(registry dygo.RecordHookRegistry) error",
+		`dygo.RecordBeforeCreate, "lead-before-create", beforeCreateLead`,
+		`dygo.RecordAfterCreate, "lead-after-create", afterCreateLead`,
+		`dygo.RecordBeforeUpdate, "lead-before-update", beforeUpdateLead`,
+		`dygo.RecordAfterUpdate, "lead-after-update", afterUpdateLead`,
+		"func beforeCreateLead(ctx context.Context, hook dygo.RecordHook) error",
+		"func afterCreateLead(ctx context.Context, hook dygo.RecordHook) error",
+		"func beforeUpdateLead(ctx context.Context, hook dygo.RecordHook) error",
+		"func afterUpdateLead(ctx context.Context, hook dygo.RecordHook) error",
 	} {
 		if !strings.Contains(hookSource, want) {
 			t.Fatalf("hook source = %q, want substring %q", hookSource, want)
@@ -105,7 +105,7 @@ func TestGenerateFailsSafelyForExistingHookWithoutRegister(t *testing.T) {
 	if err == nil {
 		t.Fatal("Generate() error = nil, want existing hook error")
 	}
-	for _, want := range []string{"hooks.go exists but does not expose Register", "sdk.RecordHookRegistry"} {
+	for _, want := range []string{"hooks.go exists but does not expose Register", "dygo.RecordHookRegistry"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("Generate() error = %q, want substring %q", err.Error(), want)
 		}
@@ -142,7 +142,7 @@ func TestGenerateUsesEntityBundleAndKebabEntityName(t *testing.T) {
 	}
 
 	hookSource := readTestFile(t, filepath.Join(root, "apps", "sales", "entities", "lead-status", "hooks.go"))
-	for _, want := range []string{"func Register(registry sdk.RecordHookRegistry) error", "beforeCreateLeadStatus", "afterCreateLeadStatus", "beforeUpdateLeadStatus", "afterUpdateLeadStatus"} {
+	for _, want := range []string{"func Register(registry dygo.RecordHookRegistry) error", "beforeCreateLeadStatus", "afterCreateLeadStatus", "beforeUpdateLeadStatus", "afterUpdateLeadStatus"} {
 		if !strings.Contains(hookSource, want) {
 			t.Fatalf("hook source = %q, want substring %q", hookSource, want)
 		}
@@ -159,9 +159,9 @@ func TestGeneratePreservesExistingEntityHookFile(t *testing.T) {
 	writeTestEntity(t, root, "sales", "lead")
 	existing := `package hooks
 
-import "github.com/hapyco/dygo/pkg/sdk"
+import "github.com/hapyco/dygo/pkg/dygo"
 
-func Register(registry sdk.RecordHookRegistry) error {
+func Register(registry dygo.RecordHookRegistry) error {
 	return nil
 }
 `
@@ -192,9 +192,9 @@ func TestGeneratePreservesLegacyGeneratedHeaderHookFile(t *testing.T) {
 
 package hooks
 
-import "github.com/hapyco/dygo/pkg/sdk"
+import "github.com/hapyco/dygo/pkg/dygo"
 
-func Register(registry sdk.RecordHookRegistry) error {
+func Register(registry dygo.RecordHookRegistry) error {
 	return nil
 }
 `

--- a/internal/hooks/record_hooks.go
+++ b/internal/hooks/record_hooks.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 
 	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/internal/dygodata"
 	"github.com/hapyco/dygo/internal/hookevents"
 	jobstore "github.com/hapyco/dygo/internal/jobs/store"
-	"github.com/hapyco/dygo/internal/sdkdata"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 // NewRecordHookRegistry returns dygo's framework hooks plus compiled app hooks.
-func NewRecordHookRegistry(registrars []sdk.RecordHookRegistrar) (*db.RecordHookRegistry, error) {
+func NewRecordHookRegistry(registrars []dygo.RecordHookRegistrar) (*db.RecordHookRegistry, error) {
 	registry := db.DefaultRecordHookRegistry()
 	adapter := recordHookRegistry{registry: registry}
 	for index, registrar := range registrars {
@@ -31,7 +31,7 @@ type recordHookRegistry struct {
 	registry *db.RecordHookRegistry
 }
 
-func (r recordHookRegistry) RegisterEntity(appName string, entity string, event sdk.RecordHookEvent, name string, fn sdk.RecordHookFunc) error {
+func (r recordHookRegistry) RegisterEntity(appName string, entity string, event dygo.RecordHookEvent, name string, fn dygo.RecordHookFunc) error {
 	if fn == nil {
 		return fmt.Errorf("record hook %q function is required", name)
 	}
@@ -40,16 +40,17 @@ func (r recordHookRegistry) RegisterEntity(appName string, entity string, event 
 		return err
 	}
 	return r.registry.RegisterEntity(appName, entity, dbEvent, name, func(ctx context.Context, hookCtx db.RecordHookContext) error {
-		var jobs sdk.JobData
+		var jobs dygo.JobData
 		if beginner, ok := hookCtx.Queryer.(jobstore.Beginner); ok {
-			jobData, err := sdkdata.NewJobDataFromBeginner(beginner)
+			jobData, err := dygodata.NewJobDataFromBeginner(beginner)
 			if err != nil {
 				return err
 			}
 			jobs = jobData
 		}
-		return fn(ctx, sdk.RecordHook{
-			Event:       sdk.RecordHookEvent(hookCtx.Event),
+		ctx = withRecordHookLogContext(ctx, hookCtx)
+		return fn(ctx, dygo.RecordHook{
+			Event:       dygo.RecordHookEvent(hookCtx.Event),
 			Operation:   hookCtx.Operation,
 			EntityID:    hookCtx.EntityID,
 			AppName:     hookCtx.AppName,
@@ -57,18 +58,44 @@ func (r recordHookRegistry) RegisterEntity(appName string, entity string, event 
 			RouteSlug:   hookCtx.RouteSlug,
 			EntityLabel: hookCtx.EntityLabel,
 			RecordID:    hookCtx.RecordID,
-			Input:       sdk.RecordInput(hookCtx.Input),
-			OldRecord:   sdk.Record(hookCtx.OldRecord),
-			NewRecord:   sdk.Record(hookCtx.NewRecord),
+			Input:       dygo.RecordInput(hookCtx.Input),
+			OldRecord:   dygo.Record(hookCtx.OldRecord),
+			NewRecord:   dygo.Record(hookCtx.NewRecord),
 			Changes:     hookCtx.Changes,
-			Snapshot:    sdk.Record(hookCtx.Snapshot),
-			Records:     sdkdata.NewRecordDataWithHookPolicy(hookCtx.Queryer, db.RecordMutationHooksFrameworkOnly),
+			Snapshot:    dygo.Record(hookCtx.Snapshot),
+			Records:     dygodata.NewRecordDataWithHookPolicy(hookCtx.Queryer, db.RecordMutationHooksFrameworkOnly),
 			Jobs:        jobs,
 		})
 	})
 }
 
-func recordHookEvent(event sdk.RecordHookEvent) (db.RecordHookEvent, error) {
+func withRecordHookLogContext(ctx context.Context, hookCtx db.RecordHookContext) context.Context {
+	if hookCtx.Queryer != nil {
+		ctx = dygo.WithLogWriter(ctx, dygodata.NewLogData(hookCtx.Queryer))
+	}
+	defaults := dygo.LogContext{
+		Source:              dygo.SourceHook,
+		App:                 hookCtx.AppName,
+		ReferenceEntity:     hookCtx.AppName + "." + hookCtx.Entity,
+		ReferenceRecordID:   hookCtx.RecordID,
+		ReferenceRecordName: hookRecordName(hookCtx),
+	}
+	if actor, ok := db.ActivityActorNameFromContext(ctx); ok {
+		defaults.Actor = actor
+	}
+	return dygo.WithLogContext(ctx, defaults)
+}
+
+func hookRecordName(hookCtx db.RecordHookContext) string {
+	for _, record := range []db.Record{hookCtx.NewRecord, hookCtx.OldRecord, hookCtx.Snapshot} {
+		if name, ok := record["name"].(string); ok && name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func recordHookEvent(event dygo.RecordHookEvent) (db.RecordHookEvent, error) {
 	if !hookevents.Supported(string(event)) {
 		return "", fmt.Errorf("record hook event %q is not supported", event)
 	}

--- a/internal/hooks/record_hooks.go
+++ b/internal/hooks/record_hooks.go
@@ -70,8 +70,8 @@ func (r recordHookRegistry) RegisterEntity(appName string, entity string, event 
 }
 
 func withRecordHookLogContext(ctx context.Context, hookCtx db.RecordHookContext) context.Context {
-	if hookCtx.Queryer != nil {
-		ctx = dygo.WithLogWriter(ctx, dygodata.NewLogData(hookCtx.Queryer))
+	if hookCtx.LogQueryer != nil {
+		ctx = dygo.WithLogWriter(ctx, dygodata.NewLogData(hookCtx.LogQueryer))
 	}
 	defaults := dygo.LogContext{
 		Source:              dygo.SourceHook,

--- a/internal/hooks/record_hooks_test.go
+++ b/internal/hooks/record_hooks_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hapyco/dygo/internal/db"
 	"github.com/hapyco/dygo/internal/hookevents"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -21,17 +21,17 @@ func TestNewRecordHookRegistryAppliesRegistrarsInOrder(t *testing.T) {
 	t.Parallel()
 
 	var order []string
-	registry, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "first", func(_ context.Context, dygo sdk.RecordHook) error {
-				order = append(order, "first:"+dygo.Entity)
-				dygo.Input["status"] = json.RawMessage(`"qualified"`)
+	registry, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "first", func(_ context.Context, hook dygo.RecordHook) error {
+				order = append(order, "first:"+hook.Entity)
+				hook.Input["status"] = json.RawMessage(`"qualified"`)
 				return nil
 			})
 		},
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "second", func(_ context.Context, dygo sdk.RecordHook) error {
-				order = append(order, "second:"+string(dygo.Event))
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "second", func(_ context.Context, hook dygo.RecordHook) error {
+				order = append(order, "second:"+string(hook.Event))
 				return nil
 			})
 		},
@@ -43,7 +43,7 @@ func TestNewRecordHookRegistryAppliesRegistrarsInOrder(t *testing.T) {
 	input := db.RecordInput{"status": json.RawMessage(`"new"`)}
 	err = registry.Run(context.Background(), db.RecordHookContext{
 		Event:       db.RecordBeforeCreate,
-		Operation:   sdk.RecordOperationCreate,
+		Operation:   dygo.RecordOperationCreate,
 		EntityID:    7,
 		AppName:     "sales",
 		Entity:      "lead",
@@ -64,7 +64,7 @@ func TestNewRecordHookRegistryAppliesRegistrarsInOrder(t *testing.T) {
 
 func TestRecordHookEventMapsAllSDKEvents(t *testing.T) {
 	t.Parallel()
-	sdkEvents := sdk.SupportedRecordHookEvents()
+	sdkEvents := dygo.SupportedRecordHookEvents()
 	specs := hookevents.Specs()
 	if len(sdkEvents) != len(specs) {
 		t.Fatalf("SDK events = %#v, specs = %#v; want matching counts", sdkEvents, specs)
@@ -74,10 +74,10 @@ func TestRecordHookEventMapsAllSDKEvents(t *testing.T) {
 		t.Run(spec.Name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := sdkEvents[index]; got != sdk.RecordHookEvent(spec.Name) {
+			if got := sdkEvents[index]; got != dygo.RecordHookEvent(spec.Name) {
 				t.Fatalf("SDK event %d = %q, want %q", index, got, spec.Name)
 			}
-			got, err := recordHookEvent(sdk.RecordHookEvent(spec.Name))
+			got, err := recordHookEvent(dygo.RecordHookEvent(spec.Name))
 			if err != nil {
 				t.Fatalf("recordHookEvent(%q) error = %v, want nil", spec.Name, err)
 			}
@@ -91,9 +91,9 @@ func TestRecordHookEventMapsAllSDKEvents(t *testing.T) {
 func TestNewRecordHookRegistryRejectsUnsupportedSDKEvent(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordHookEvent("after-save"), "legacy-save", func(context.Context, sdk.RecordHook) error {
+	_, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordHookEvent("after-save"), "legacy-save", func(context.Context, dygo.RecordHook) error {
 				return nil
 			})
 		},
@@ -114,8 +114,8 @@ func TestNewRecordHookRegistryRejectsUnsupportedSDKEvent(t *testing.T) {
 func TestNewRecordHookRegistryReturnsRegistrarErrors(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(sdk.RecordHookRegistry) error {
+	_, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(dygo.RecordHookRegistry) error {
 			return errors.New("boom")
 		},
 	})
@@ -132,13 +132,13 @@ func TestNewRecordHookRegistryExposesTransactionalRecordData(t *testing.T) {
 
 	queryer := &failingRecordQueryer{err: errors.New("metadata lookup failed")}
 	var dataErr error
-	registry, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "read-related-record", func(ctx context.Context, dygo sdk.RecordHook) error {
-				if dygo.Records == nil {
+	registry, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "read-related-record", func(ctx context.Context, hook dygo.RecordHook) error {
+				if hook.Records == nil {
 					return errors.New("record data service is nil")
 				}
-				_, dataErr = dygo.Records.Get(ctx, "sales", "lead", 42)
+				_, dataErr = hook.Records.Get(ctx, "sales", "lead", 42)
 				return nil
 			})
 		},
@@ -149,7 +149,7 @@ func TestNewRecordHookRegistryExposesTransactionalRecordData(t *testing.T) {
 
 	err = registry.Run(context.Background(), db.RecordHookContext{
 		Event:     db.RecordBeforeCreate,
-		Operation: sdk.RecordOperationCreate,
+		Operation: dygo.RecordOperationCreate,
 		AppName:   "sales",
 		Entity:    "lead",
 		Queryer:   queryer,
@@ -176,10 +176,10 @@ func TestNewRecordHookRegistryExposesJobDataForTransactionalHooks(t *testing.T) 
 
 	queryer := &beginnerRecordQueryer{failingRecordQueryer: &failingRecordQueryer{err: errors.New("unused")}}
 	var hasJobs bool
-	registry, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "enqueue-background-work", func(_ context.Context, dygo sdk.RecordHook) error {
-				hasJobs = dygo.Jobs != nil
+	registry, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "enqueue-background-work", func(_ context.Context, hook dygo.RecordHook) error {
+				hasJobs = hook.Jobs != nil
 				return nil
 			})
 		},
@@ -206,14 +206,14 @@ func TestRecordDataListPassesFiltersAndSortThroughHookQueryer(t *testing.T) {
 	t.Parallel()
 
 	queryer := newUserRecordDataMutationQueryer(userRecordRow("a@example.com", "A User", true))
-	var result sdk.RecordListResult
+	var result dygo.RecordListResult
 	var listErr error
-	registry, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "list-users", func(ctx context.Context, dygo sdk.RecordHook) error {
-				result, listErr = dygo.Records.List(ctx, "core", "user", sdk.RecordListParams{
-					Filters: []sdk.RecordFilter{{Field: "enabled", Operator: "eq", Value: "true"}},
-					Sort:    []sdk.RecordSort{{Field: "full-name", Desc: true}},
+	registry, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "list-users", func(ctx context.Context, hook dygo.RecordHook) error {
+				result, listErr = hook.Records.List(ctx, "core", "user", dygo.RecordListParams{
+					Filters: []dygo.RecordFilter{{Field: "enabled", Operator: "eq", Value: "true"}},
+					Sort:    []dygo.RecordSort{{Field: "full-name", Desc: true}},
 				})
 				return nil
 			})
@@ -225,7 +225,7 @@ func TestRecordDataListPassesFiltersAndSortThroughHookQueryer(t *testing.T) {
 
 	err = registry.Run(context.Background(), db.RecordHookContext{
 		Event:     db.RecordBeforeCreate,
-		Operation: sdk.RecordOperationCreate,
+		Operation: dygo.RecordOperationCreate,
 		AppName:   "sales",
 		Entity:    "lead",
 		Queryer:   queryer,
@@ -259,15 +259,15 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 	tests := []struct {
 		name    string
 		queryer func() *recordDataMutationQueryer
-		mutate  func(context.Context, sdk.RecordHook) error
+		mutate  func(context.Context, dygo.RecordHook) error
 	}{
 		{
 			name: "create",
 			queryer: func() *recordDataMutationQueryer {
 				return newUserRecordDataMutationQueryer(userRecordRow("a@example.com", "A User", true))
 			},
-			mutate: func(ctx context.Context, dygo sdk.RecordHook) error {
-				_, err := dygo.Records.Create(ctx, "core", "user", sdk.RecordInput{
+			mutate: func(ctx context.Context, hook dygo.RecordHook) error {
+				_, err := hook.Records.Create(ctx, "core", "user", dygo.RecordInput{
 					"email":     json.RawMessage(`"a@example.com"`),
 					"full-name": json.RawMessage(`"A User"`),
 				})
@@ -282,8 +282,8 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 					userRecordRow("a@example.com", "Renamed User", true),
 				)
 			},
-			mutate: func(ctx context.Context, dygo sdk.RecordHook) error {
-				_, err := dygo.Records.Update(ctx, "core", "user", 7, sdk.RecordInput{
+			mutate: func(ctx context.Context, hook dygo.RecordHook) error {
+				_, err := hook.Records.Update(ctx, "core", "user", 7, dygo.RecordInput{
 					"full-name": json.RawMessage(`"Renamed User"`),
 				})
 				return err
@@ -296,8 +296,8 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 				queryer.execTags = []pgconn.CommandTag{pgconn.NewCommandTag("DELETE 1")}
 				return queryer
 			},
-			mutate: func(ctx context.Context, dygo sdk.RecordHook) error {
-				return dygo.Records.Delete(ctx, "core", "user", 7)
+			mutate: func(ctx context.Context, hook dygo.RecordHook) error {
+				return hook.Records.Delete(ctx, "core", "user", 7)
 			},
 		},
 	}
@@ -309,17 +309,17 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 			queryer := tt.queryer()
 			var outerCalls int
 			var reentryCalls int
-			registry, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-				func(registry sdk.RecordHookRegistry) error {
-					if err := registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "outer-"+tt.name, func(ctx context.Context, dygo sdk.RecordHook) error {
+			registry, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+				func(registry dygo.RecordHookRegistry) error {
+					if err := registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "outer-"+tt.name, func(ctx context.Context, hook dygo.RecordHook) error {
 						outerCalls++
-						return tt.mutate(ctx, dygo)
+						return tt.mutate(ctx, hook)
 					}); err != nil {
 						return err
 					}
 					for _, event := range allRecordHookEvents() {
 						event := event
-						if err := registry.RegisterEntity("core", "user", event, "reentry-"+string(event), func(context.Context, sdk.RecordHook) error {
+						if err := registry.RegisterEntity("core", "user", event, "reentry-"+string(event), func(context.Context, dygo.RecordHook) error {
 							reentryCalls++
 							return nil
 						}); err != nil {
@@ -335,7 +335,7 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 
 			err = registry.Run(context.Background(), db.RecordHookContext{
 				Event:     db.RecordBeforeCreate,
-				Operation: sdk.RecordOperationCreate,
+				Operation: dygo.RecordOperationCreate,
 				AppName:   "sales",
 				Entity:    "lead",
 				Queryer:   queryer,
@@ -347,7 +347,7 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 				t.Fatalf("outer hook calls = %d, want 1", outerCalls)
 			}
 			if reentryCalls != 0 {
-				t.Fatalf("inner app hook calls = %d, want dygo.Records mutation without app hook re-entry", reentryCalls)
+				t.Fatalf("inner app hook calls = %d, want hook.Records mutation without app hook re-entry", reentryCalls)
 			}
 			if !queryer.executedSQLContaining(`INSERT INTO "activity"`) {
 				t.Fatalf("exec SQL = %#v, want framework Activity hook to stay active", queryer.execSQL)
@@ -356,14 +356,14 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 	}
 }
 
-func allRecordHookEvents() []sdk.RecordHookEvent {
-	return sdk.SupportedRecordHookEvents()
+func allRecordHookEvents() []dygo.RecordHookEvent {
+	return dygo.SupportedRecordHookEvents()
 }
 
 func TestNewRecordHookRegistryRejectsNilRegistrarAndHook(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewRecordHookRegistry([]sdk.RecordHookRegistrar{nil})
+	_, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{nil})
 	if err == nil {
 		t.Fatal("NewRecordHookRegistry(nil registrar) error = nil, want error")
 	}
@@ -371,9 +371,9 @@ func TestNewRecordHookRegistryRejectsNilRegistrarAndHook(t *testing.T) {
 		t.Fatalf("NewRecordHookRegistry(nil registrar) error = %q, want nil registrar context", err.Error())
 	}
 
-	_, err = NewRecordHookRegistry([]sdk.RecordHookRegistrar{
-		func(registry sdk.RecordHookRegistry) error {
-			return registry.RegisterEntity("sales", "lead", sdk.RecordBeforeCreate, "missing", nil)
+	_, err = NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "missing", nil)
 		},
 	})
 	if err == nil {

--- a/internal/hooks/record_hooks_test.go
+++ b/internal/hooks/record_hooks_test.go
@@ -356,6 +356,59 @@ func TestRecordDataMutationsDoNotReenterAppHooks(t *testing.T) {
 	}
 }
 
+func TestRecordHookLogsUseLogQueryerOutsideRecordQueryer(t *testing.T) {
+	t.Parallel()
+
+	recordQueryer := newUserRecordDataMutationQueryer(userRecordRow("a@example.com", "A User", true))
+	logQueryer := newLogRecordDataMutationQueryer()
+	hookErr := errors.New("blocked by hook")
+	var recordErr error
+	registry, err := NewRecordHookRegistry([]dygo.RecordHookRegistrar{
+		func(registry dygo.RecordHookRegistry) error {
+			return registry.RegisterEntity("sales", "lead", dygo.RecordBeforeCreate, "log-and-reject", func(ctx context.Context, hook dygo.RecordHook) error {
+				_, recordErr = hook.Records.Create(ctx, "core", "user", dygo.RecordInput{
+					"email":     json.RawMessage(`"a@example.com"`),
+					"full-name": json.RawMessage(`"A User"`),
+				})
+				dygo.Error(ctx, "Lead hook failed", hookErr)
+				return hookErr
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRecordHookRegistry() error = %v, want nil", err)
+	}
+
+	err = registry.Run(context.Background(), db.RecordHookContext{
+		Event:      db.RecordBeforeCreate,
+		Operation:  dygo.RecordOperationCreate,
+		AppName:    "sales",
+		Entity:     "lead",
+		Queryer:    recordQueryer,
+		LogQueryer: logQueryer,
+	})
+	if err == nil || !strings.Contains(err.Error(), hookErr.Error()) {
+		t.Fatalf("Run() error = %v, want hook error", err)
+	}
+	if recordErr != nil {
+		t.Fatalf("hook.Records.Create() error = %v, want nil", recordErr)
+	}
+	if !recordQueryer.queriedSQLContaining(`INSERT INTO "user"`) {
+		t.Fatalf("record queries = %#v, want hook record write through record queryer", recordQueryer.queries)
+	}
+	if recordQueryer.executedSQLContaining(`INSERT INTO "log"`) {
+		t.Fatalf("record exec SQL = %#v, want no Log insert through record queryer", recordQueryer.execSQL)
+	}
+	if !logQueryer.executedSQLContaining(`INSERT INTO "log"`) {
+		t.Fatalf("log exec SQL = %#v, want Log insert through log queryer", logQueryer.execSQL)
+	}
+	for _, want := range []any{"Error", "Hook", "Lead hook failed", hookErr.Error()} {
+		if !logQueryer.executedArg(want) {
+			t.Fatalf("log exec args = %#v, want %q", logQueryer.execArg, want)
+		}
+	}
+}
+
 func allRecordHookEvents() []dygo.RecordHookEvent {
 	return dygo.SupportedRecordHookEvents()
 }
@@ -455,6 +508,17 @@ func newUserRecordDataMutationQueryer(recordRows ...[]any) *recordDataMutationQu
 	return queryer
 }
 
+func newLogRecordDataMutationQueryer() *recordDataMutationQueryer {
+	return &recordDataMutationQueryer{
+		row: newRecordDataMutationRow(int64(2), "core.log", "log", "log", "Log", "Diagnostic log", "file-text", false, false, false, []byte(`{"strategy":"random","length":16}`), "core", "Core"),
+		rows: []pgx.Rows{
+			newRecordDataMutationRows(hookLogFieldRows()),
+			newRecordDataMutationRows(nil),
+			newRecordDataMutationRows(nil),
+		},
+	}
+}
+
 func userRecordRow(email string, fullName string, enabled bool) []any {
 	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	return []any{int64(7), email, now, now, email, fullName, enabled}
@@ -464,6 +528,9 @@ func (q *recordDataMutationQueryer) Query(_ context.Context, sql string, args ..
 	q.queries = append(q.queries, sql)
 	q.args = append(q.args, args)
 	if rows, ok := hookActivityMetadataRows(sql, args...); ok {
+		return rows, nil
+	}
+	if rows, ok := hookLogMetadataRows(sql, args...); ok {
 		return rows, nil
 	}
 	if len(q.rows) == 0 {
@@ -479,6 +546,15 @@ func (q *recordDataMutationQueryer) QueryRow(_ context.Context, sql string, args
 	q.rowArgs = append(q.rowArgs, args)
 	if isHookActivityMetadataQuery(sql, args...) {
 		return newRecordDataMutationRow(int64(1), "core.activity", "activity", "activity", "Activity", "Timeline entry", "activity", false, false, false, []byte(`{"strategy":"random","length":16}`), "core", "Core")
+	}
+	if isHookLogMetadataQuery(sql, args...) {
+		return newRecordDataMutationRow(int64(2), "core.log", "log", "log", "Log", "Diagnostic log", "file-text", false, false, false, []byte(`{"strategy":"random","length":16}`), "core", "Core")
+	}
+	if strings.Contains(sql, `SELECT "id" FROM "app"`) && len(args) == 1 && args[0] == "sales" {
+		return newRecordDataMutationRow(int64(20))
+	}
+	if strings.Contains(sql, `SELECT "id" FROM "entity"`) && len(args) == 1 && args[0] == "sales.lead" {
+		return newRecordDataMutationRow(int64(30))
 	}
 	if strings.Contains(sql, `SELECT "id" FROM "entity"`) && len(args) == 1 && args[0] == "core.user" {
 		return newRecordDataMutationRow(int64(10))
@@ -512,11 +588,38 @@ func (q *recordDataMutationQueryer) executedSQLContaining(fragment string) bool 
 	return false
 }
 
+func (q *recordDataMutationQueryer) queriedSQLContaining(fragment string) bool {
+	for _, sql := range q.queries {
+		if strings.Contains(sql, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func (q *recordDataMutationQueryer) executedArg(want any) bool {
+	for _, args := range q.execArg {
+		for _, got := range args {
+			if got == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func isHookActivityMetadataQuery(sql string, args ...any) bool {
 	return strings.Contains(sql, `WHERE a.name = $1 AND e.key = $2`) &&
 		len(args) == 2 &&
 		args[0] == "core" &&
 		args[1] == "activity"
+}
+
+func isHookLogMetadataQuery(sql string, args ...any) bool {
+	return strings.Contains(sql, `WHERE a.name = $1 AND e.key = $2`) &&
+		len(args) == 2 &&
+		args[0] == "core" &&
+		args[1] == "log"
 }
 
 func hookActivityMetadataRows(sql string, args ...any) (pgx.Rows, bool) {
@@ -539,6 +642,31 @@ func hookActivityMetadataRows(sql string, args ...any) (pgx.Rows, bool) {
 		return newRecordDataMutationRows(nil), true
 	default:
 		return nil, false
+	}
+}
+
+func hookLogMetadataRows(sql string, args ...any) (pgx.Rows, bool) {
+	if len(args) != 1 || args[0] != int64(2) {
+		return nil, false
+	}
+	switch {
+	case strings.Contains(sql, `FROM "field"`):
+		return newRecordDataMutationRows(hookLogFieldRows()), true
+	case strings.Contains(sql, `FROM "index"`), strings.Contains(sql, `FROM "constraint"`):
+		return newRecordDataMutationRows(nil), true
+	default:
+		return nil, false
+	}
+}
+
+func hookLogFieldRows() [][]any {
+	return [][]any{
+		{int64(301), "type", "Type", "select", true, false, false, nil, nil, nil, 1, []byte(`{"values":["Debug","Info","Warning","Error","Panic"]}`)},
+		{int64(302), "source", "Source", "select", true, false, false, nil, nil, nil, 2, []byte(`{"values":["Framework","SDK","HTTP","Job","Hook","CLI","Studio"]}`)},
+		{int64(303), "app", "App", "link", false, false, false, nil, nil, nil, 3, []byte(`{"entity":"app","foreign-key":false}`)},
+		{int64(304), "title", "Title", "text", true, false, false, nil, nil, nil, 4, nil},
+		{int64(305), "message", "Message", "long-text", false, false, false, nil, nil, nil, 5, nil},
+		{int64(306), "reference-entity", "Reference Entity", "link", false, false, false, nil, nil, nil, 6, []byte(`{"entity":"entity","foreign-key":false}`)},
 	}
 }
 

--- a/internal/jobgen/jobgen.go
+++ b/internal/jobgen/jobgen.go
@@ -97,7 +97,7 @@ func GenerateWithOptions(options GenerateOptions) (Result, error) {
 	if exists, hasRun, err := runnergen.InspectFunctionFile(runFile, "Run"); err != nil {
 		return Result{}, err
 	} else if exists && !hasRun {
-		return Result{}, fmt.Errorf("%s exists but does not expose Run(ctx context.Context, job sdk.JobExecution) error", runFile)
+		return Result{}, fmt.Errorf("%s exists but does not expose Run(ctx context.Context, job dygo.JobExecution) error", runFile)
 	}
 	if err := runnergen.PreflightGeneratedFile(runnerFile, runnergen.JobManualSnippet(root, modulePath, appName, jobName, jobDir)); err != nil {
 		return Result{}, err
@@ -244,7 +244,7 @@ func runFileStatus(path string, dryRun bool) (string, error) {
 		return "created", nil
 	}
 	if !hasRun {
-		return "", fmt.Errorf("%s exists but does not expose Run(ctx context.Context, job sdk.JobExecution) error", path)
+		return "", fmt.Errorf("%s exists but does not expose Run(ctx context.Context, job dygo.JobExecution) error", path)
 	}
 	return "existing", nil
 }
@@ -265,10 +265,10 @@ func renderRunSource(appName string, jobName string) ([]byte, error) {
 import (
 	"context"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-func Run(ctx context.Context, job sdk.JobExecution) error {
+func Run(ctx context.Context, job dygo.JobExecution) error {
 	// TODO(%s/%s): implement job behavior.
 	return nil
 }

--- a/internal/jobgen/jobgen_test.go
+++ b/internal/jobgen/jobgen_test.go
@@ -31,7 +31,7 @@ func TestGenerateCreatesJobRunAndRunner(t *testing.T) {
 	}
 
 	runSource := readTestFile(t, filepath.Join(root, "apps", "sales", "jobs", "send-email", "run.go"))
-	for _, want := range []string{"package job", "func Run(ctx context.Context, job sdk.JobExecution) error", "TODO(sales/send-email): implement job behavior"} {
+	for _, want := range []string{"package job", "func Run(ctx context.Context, job dygo.JobExecution) error", "TODO(sales/send-email): implement job behavior"} {
 		if !strings.Contains(runSource, want) {
 			t.Fatalf("run.go = %q, want substring %q", runSource, want)
 		}
@@ -40,7 +40,7 @@ func TestGenerateCreatesJobRunAndRunner(t *testing.T) {
 	runnerSource := readTestFile(t, filepath.Join(root, "cmd", "dygo", "main.go"))
 	for _, want := range []string{
 		`salessendemailjob "example.com/acme/apps/sales/jobs/send-email"`,
-		"Jobs: []sdk.JobRegistrar{",
+		"Jobs: []dygo.JobRegistrar{",
 		`return registry.RegisterJob("sales", "send-email", salessendemailjob.Run)`,
 	} {
 		if !strings.Contains(runnerSource, want) {
@@ -78,10 +78,10 @@ timeout: 30s
 import (
 	"context"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-func Run(ctx context.Context, job sdk.JobExecution) error {
+func Run(ctx context.Context, job dygo.JobExecution) error {
 	return nil
 }
 `
@@ -112,7 +112,7 @@ func TestGenerateFailsForExistingRunWithoutRunFunction(t *testing.T) {
 	if err == nil {
 		t.Fatal("Generate() error = nil, want missing Run error")
 	}
-	if !strings.Contains(err.Error(), "does not expose Run(ctx context.Context, job sdk.JobExecution) error") {
+	if !strings.Contains(err.Error(), "does not expose Run(ctx context.Context, job dygo.JobExecution) error") {
 		t.Fatalf("Generate() error = %q, want missing Run message", err.Error())
 	}
 	assertPathMissing(t, filepath.Join(root, "cmd", "dygo", "main.go"))
@@ -132,8 +132,8 @@ func TestHookGenerationPreservesJobRunnerWiring(t *testing.T) {
 
 	runnerSource := readTestFile(t, filepath.Join(root, "cmd", "dygo", "main.go"))
 	for _, want := range []string{
-		"RecordHooks: []sdk.RecordHookRegistrar{",
-		"Jobs: []sdk.JobRegistrar{",
+		"RecordHooks: []dygo.RecordHookRegistrar{",
+		"Jobs: []dygo.JobRegistrar{",
 		"salesleadhooks.Register",
 		`return registry.RegisterJob("sales", "send-email", salessendemailjob.Run)`,
 	} {

--- a/internal/jobs/runtime/runtime.go
+++ b/internal/jobs/runtime/runtime.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/internal/dygodata"
 	jobstore "github.com/hapyco/dygo/internal/jobs/store"
 	namegen "github.com/hapyco/dygo/internal/naming"
-	"github.com/hapyco/dygo/internal/sdkdata"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 const (
@@ -28,7 +28,7 @@ const (
 
 // Registry stores compiled Job handlers.
 type Registry struct {
-	handlers map[string]sdk.JobFunc
+	handlers map[string]dygo.JobFunc
 }
 
 // Queue is one worker queue with effective concurrency.
@@ -88,8 +88,8 @@ type Result struct {
 }
 
 // NewRegistry returns a Registry populated by compiled app registrars.
-func NewRegistry(registrars []sdk.JobRegistrar) (*Registry, error) {
-	registry := &Registry{handlers: map[string]sdk.JobFunc{}}
+func NewRegistry(registrars []dygo.JobRegistrar) (*Registry, error) {
+	registry := &Registry{handlers: map[string]dygo.JobFunc{}}
 	adapter := registryAdapter{registry: registry}
 	for index, registrar := range registrars {
 		if registrar == nil {
@@ -103,7 +103,7 @@ func NewRegistry(registrars []sdk.JobRegistrar) (*Registry, error) {
 }
 
 // RegisterJob stores one compiled Job handler.
-func (r *Registry) RegisterJob(appName string, jobName string, fn sdk.JobFunc) error {
+func (r *Registry) RegisterJob(appName string, jobName string, fn dygo.JobFunc) error {
 	if fn == nil {
 		return fmt.Errorf("job %s/%s function is required", appName, jobName)
 	}
@@ -112,7 +112,7 @@ func (r *Registry) RegisterJob(appName string, jobName string, fn sdk.JobFunc) e
 		return err
 	}
 	if r.handlers == nil {
-		r.handlers = map[string]sdk.JobFunc{}
+		r.handlers = map[string]dygo.JobFunc{}
 	}
 	if _, ok := r.handlers[key]; ok {
 		return fmt.Errorf("job %s/%s is already registered", appName, jobName)
@@ -121,7 +121,7 @@ func (r *Registry) RegisterJob(appName string, jobName string, fn sdk.JobFunc) e
 	return nil
 }
 
-func (r *Registry) handler(appName string, jobName string) (sdk.JobFunc, bool) {
+func (r *Registry) handler(appName string, jobName string) (dygo.JobFunc, bool) {
 	if r == nil {
 		return nil, false
 	}
@@ -133,7 +133,7 @@ type registryAdapter struct {
 	registry *Registry
 }
 
-func (r registryAdapter) RegisterJob(appName string, jobName string, fn sdk.JobFunc) error {
+func (r registryAdapter) RegisterJob(appName string, jobName string, fn dygo.JobFunc) error {
 	return r.registry.RegisterJob(appName, jobName, fn)
 }
 
@@ -382,21 +382,30 @@ func (w Worker) runExecution(ctx context.Context, execution jobstore.Execution, 
 	}
 
 	w.log("running %s/%s execution %d attempt %d", execution.AppName, execution.JobName, execution.ID, execution.Attempts)
-	finalizeCtx := context.WithoutCancel(ctx)
+	finalizeCtx := w.withJobLogContext(context.WithoutCancel(ctx), execution)
 	runCtx, cancel := context.WithTimeout(ctx, execution.Timeout)
+	runCtx = w.withJobLogContext(runCtx, execution)
 	defer cancel()
-	err := runJobHandler(fn, runCtx, sdk.JobExecution{
+	err := runJobHandler(fn, runCtx, dygo.JobExecution{
 		ID:      execution.ID,
 		AppName: execution.AppName,
 		JobName: execution.JobName,
 		Queue:   execution.Queue,
 		Attempt: execution.Attempts,
 		Payload: execution.Payload,
-		Records: sdkdata.NewRecordData(w.Queryer, w.RecordHooks),
-		Jobs:    sdkdata.NewJobData(w.Store),
+		Records: dygodata.NewRecordData(w.Queryer, w.RecordHooks),
+		Jobs:    dygodata.NewJobData(w.Store),
 	})
 	if err == nil && runCtx.Err() == context.DeadlineExceeded {
 		err = context.DeadlineExceeded
+	}
+	var panicErr jobPanicError
+	if errors.As(err, &panicErr) {
+		dygo.Panic(finalizeCtx, "Job handler panic", panicErr,
+			dygo.WithReference("core", "job-execution", execution.ID),
+			dygo.WithMetadata("job", execution.JobName),
+			dygo.WithMetadata("attempt", execution.Attempts),
+		)
 	}
 	if err == nil {
 		if err := w.Store.Complete(finalizeCtx, execution, nil, options.Now()); err != nil {
@@ -424,13 +433,31 @@ func (w Worker) runExecution(ctx context.Context, execution jobstore.Execution, 
 	return Result{Failed: 1}, nil
 }
 
-func runJobHandler(fn sdk.JobFunc, ctx context.Context, execution sdk.JobExecution) (err error) {
+func (w Worker) withJobLogContext(ctx context.Context, execution jobstore.Execution) context.Context {
+	if w.Queryer != nil {
+		ctx = dygo.WithLogWriter(ctx, dygodata.NewLogData(w.Queryer))
+	}
+	return dygo.WithLogContext(ctx, dygo.LogContext{
+		Source: dygo.SourceJob,
+		App:    execution.AppName,
+	})
+}
+
+func runJobHandler(fn dygo.JobFunc, ctx context.Context, execution dygo.JobExecution) (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("panic: %v", recovered)
+			err = jobPanicError{value: recovered}
 		}
 	}()
 	return fn(ctx, execution)
+}
+
+type jobPanicError struct {
+	value any
+}
+
+func (err jobPanicError) Error() string {
+	return fmt.Sprintf("panic: %v", err.value)
 }
 
 func (w Worker) shutdownActiveExecutions(ctx context.Context, inFlight *sync.WaitGroup, active *activeExecutions, options Options) {

--- a/internal/jobs/runtime/runtime_test.go
+++ b/internal/jobs/runtime/runtime_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	jobstore "github.com/hapyco/dygo/internal/jobs/store"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 func TestWorkerRunOnceCompletesRegisteredJob(t *testing.T) {
@@ -27,9 +27,9 @@ func TestWorkerRunOnceCompletesRegisteredJob(t *testing.T) {
 			Payload:     json.RawMessage(`{"email":"a@example.com"}`),
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(_ context.Context, execution sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(_ context.Context, execution dygo.JobExecution) error {
 				if execution.ID != 42 || execution.AppName != "crm" || execution.JobName != "send-email" || execution.Attempt != 1 {
 					t.Fatalf("job execution = %+v, want claimed execution context", execution)
 				}
@@ -78,9 +78,9 @@ func TestWorkerRunOnceEnqueuesDueSchedulesBeforeClaim(t *testing.T) {
 			Timeout:     time.Minute,
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(context.Context, dygo.JobExecution) error {
 				return nil
 			})
 		},
@@ -155,9 +155,9 @@ func TestWorkerRunOnceRecordsHandlerFailure(t *testing.T) {
 			Timeout:  time.Minute,
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(context.Context, dygo.JobExecution) error {
 				return errors.New("smtp unavailable")
 			})
 		},
@@ -195,9 +195,9 @@ func TestWorkerRunOnceRecordsHandlerPanic(t *testing.T) {
 			Timeout:  time.Minute,
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(context.Context, dygo.JobExecution) error {
 				panic("nil template")
 			})
 		},
@@ -235,9 +235,9 @@ func TestWorkerRunOnceTreatsLateSuccessAfterTimeoutAsFailure(t *testing.T) {
 			Timeout:  10 * time.Millisecond,
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "slow-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "slow-email", func(context.Context, dygo.JobExecution) error {
 				time.Sleep(25 * time.Millisecond)
 				return nil
 			})
@@ -287,9 +287,9 @@ func TestWorkerRunContinuousNotificationWakesBeforePoll(t *testing.T) {
 		claimSignal: firstClaimed,
 	}
 	listener := newFakeListener()
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(context.Context, dygo.JobExecution) error {
 				cancel()
 				return nil
 			})
@@ -349,9 +349,9 @@ func TestWorkerRunContinuousUsesNextRunAfterBeforePoll(t *testing.T) {
 		},
 		nextRunAfter: ptrTime(now.Add(20 * time.Millisecond)),
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(context.Context, dygo.JobExecution) error {
 				cancel()
 				return nil
 			})
@@ -404,9 +404,9 @@ func TestWorkerRunContinuousUsesNextScheduleRunAtBeforePoll(t *testing.T) {
 		},
 		nextScheduleRunAt: ptrTime(now.Add(20 * time.Millisecond)),
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "send-email", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "send-email", func(context.Context, dygo.JobExecution) error {
 				cancel()
 				return nil
 			})
@@ -462,9 +462,9 @@ func TestWorkerRunContinuousExpiresActiveClaimAfterShutdownTimeout(t *testing.T)
 			Timeout:  time.Hour,
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "slow-import", func(context.Context, sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "slow-import", func(context.Context, dygo.JobExecution) error {
 				defer close(handlerDone)
 				close(started)
 				<-release
@@ -529,9 +529,9 @@ func TestWorkerRunContinuousPassesShutdownCancellationToHandler(t *testing.T) {
 			Timeout:  time.Hour,
 		}},
 	}
-	registry, err := NewRegistry([]sdk.JobRegistrar{
-		func(registry sdk.JobRegistry) error {
-			return registry.RegisterJob("crm", "slow-import", func(ctx context.Context, _ sdk.JobExecution) error {
+	registry, err := NewRegistry([]dygo.JobRegistrar{
+		func(registry dygo.JobRegistry) error {
+			return registry.RegisterJob("crm", "slow-import", func(ctx context.Context, _ dygo.JobExecution) error {
 				close(started)
 				<-ctx.Done()
 				close(cancelled)

--- a/internal/projectgen/projectgen.go
+++ b/internal/projectgen/projectgen.go
@@ -354,7 +354,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	dygoruntime "github.com/hapyco/dygo/pkg/sdk/runtime"
+	dygoruntime "github.com/hapyco/dygo/pkg/dygo/runtime"
 )
 
 func main() {

--- a/internal/runnergen/runnergen.go
+++ b/internal/runnergen/runnergen.go
@@ -503,9 +503,9 @@ func RenderSource(hookFiles []HookFile, jobFiles []JobFile) ([]byte, error) {
 		builder.WriteString(fmt.Sprintf("\t%s %q\n", job.Alias, job.ImportPath))
 	}
 	if len(wiredHooks) > 0 || len(wiredJobs) > 0 {
-		builder.WriteString("\t\"github.com/hapyco/dygo/pkg/sdk\"\n")
+		builder.WriteString("\t\"github.com/hapyco/dygo/pkg/dygo\"\n")
 	}
-	builder.WriteString("\tdygoruntime \"github.com/hapyco/dygo/pkg/sdk/runtime\"\n")
+	builder.WriteString("\tdygoruntime \"github.com/hapyco/dygo/pkg/dygo/runtime\"\n")
 	builder.WriteString(")\n\n")
 	builder.WriteString("func main() {\n")
 	builder.WriteString("\tctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)\n")
@@ -516,16 +516,16 @@ func RenderSource(hookFiles []HookFile, jobFiles []JobFile) ([]byte, error) {
 	} else {
 		builder.WriteString(", dygoruntime.Options{\n")
 		if len(wiredHooks) > 0 {
-			builder.WriteString("\t\tRecordHooks: []sdk.RecordHookRegistrar{\n")
+			builder.WriteString("\t\tRecordHooks: []dygo.RecordHookRegistrar{\n")
 			for _, hook := range wiredHooks {
 				builder.WriteString(fmt.Sprintf("\t\t\t%s.Register,\n", hook.Alias))
 			}
 			builder.WriteString("\t\t},\n")
 		}
 		if len(wiredJobs) > 0 {
-			builder.WriteString("\t\tJobs: []sdk.JobRegistrar{\n")
+			builder.WriteString("\t\tJobs: []dygo.JobRegistrar{\n")
 			for _, job := range wiredJobs {
-				builder.WriteString("\t\t\tfunc(registry sdk.JobRegistry) error {\n")
+				builder.WriteString("\t\t\tfunc(registry dygo.JobRegistry) error {\n")
 				builder.WriteString(fmt.Sprintf("\t\t\t\treturn registry.RegisterJob(%q, %q, %s.Run)\n", job.AppName, job.JobName, job.Alias))
 				builder.WriteString("\t\t\t},\n")
 			}
@@ -577,7 +577,7 @@ func HookManualSnippet(root string, modulePath string, appName string, entityNam
 	}
 	return fmt.Sprintf(`import %s %q
 
-RecordHooks: []sdk.RecordHookRegistrar{%s.Register},`, alias, importPath, alias)
+RecordHooks: []dygo.RecordHookRegistrar{%s.Register},`, alias, importPath, alias)
 }
 
 // JobManualSnippet returns wiring help for a custom project runner.
@@ -592,8 +592,8 @@ func JobManualSnippet(root string, modulePath string, appName string, jobName st
 	}
 	return fmt.Sprintf(`import %s %q
 
-Jobs: []sdk.JobRegistrar{
-	func(registry sdk.JobRegistry) error {
+Jobs: []dygo.JobRegistrar{
+	func(registry dygo.JobRegistry) error {
 		return registry.RegisterJob(%q, %q, %s.Run)
 	},
 },`, alias, importPath, appName, jobName, alias)
@@ -601,7 +601,7 @@ Jobs: []sdk.JobRegistrar{
 
 // UpgradeManualSnippet returns generic wiring help for custom runners.
 func UpgradeManualSnippet() string {
-	return `cmd/dygo/main.go is custom. Import app hook and Job packages manually and call pkg/sdk/runtime.Run with runtime.Options{RecordHooks: ..., Jobs: ...}.`
+	return `cmd/dygo/main.go is custom. Import app hook and Job packages manually and call pkg/dygo/runtime.Run with runtime.Options{RecordHooks: ..., Jobs: ...}.`
 }
 
 // ExportedIdentifier returns a Go exported identifier from a kebab key.

--- a/pkg/dygo/hooks.go
+++ b/pkg/dygo/hooks.go
@@ -1,5 +1,5 @@
-// Package sdk exposes the public extension points app code can compile against.
-package sdk
+// Package dygo exposes the public extension points app code can compile against.
+package dygo
 
 import (
 	"context"

--- a/pkg/dygo/jobs.go
+++ b/pkg/dygo/jobs.go
@@ -1,4 +1,4 @@
-package sdk
+package dygo
 
 import (
 	"context"

--- a/pkg/dygo/logs.go
+++ b/pkg/dygo/logs.go
@@ -1,0 +1,330 @@
+package dygo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hapyco/dygo/internal/corevalues"
+)
+
+// LogType is the stored type of a persisted Log.
+type LogType string
+
+const (
+	TypeDebug   LogType = corevalues.LogTypeDebug
+	TypeInfo    LogType = corevalues.LogTypeInfo
+	TypeWarning LogType = corevalues.LogTypeWarning
+	TypeError   LogType = corevalues.LogTypeError
+	TypePanic   LogType = corevalues.LogTypePanic
+)
+
+// LogSource is the stored runtime surface that wrote a Log.
+type LogSource string
+
+const (
+	SourceFramework LogSource = corevalues.LogSourceFramework
+	SourceSDK       LogSource = corevalues.LogSourceSDK
+	SourceHTTP      LogSource = corevalues.LogSourceHTTP
+	SourceJob       LogSource = corevalues.LogSourceJob
+	SourceHook      LogSource = corevalues.LogSourceHook
+	SourceCLI       LogSource = corevalues.LogSourceCLI
+	SourceStudio    LogSource = corevalues.LogSourceStudio
+)
+
+// LogEntry is one persisted diagnostic event.
+type LogEntry struct {
+	Type                LogType
+	Source              LogSource
+	App                 string
+	Title               string
+	Message             string
+	TraceID             string
+	ReferenceEntity     string
+	ReferenceRecordID   int64
+	ReferenceRecordName string
+	Actor               string
+	Metadata            map[string]any
+}
+
+// LogWriter persists Log entries for dygo helper functions.
+type LogWriter interface {
+	WriteLog(context.Context, LogEntry) error
+}
+
+// ErrLogWriterUnavailable means ctx does not contain a LogWriter.
+var ErrLogWriterUnavailable = errors.New("dygo log writer is unavailable")
+
+type logWriterContextKey struct{}
+type logContextKey struct{}
+
+// LogContext carries runtime defaults that dygo applies to LogEntry values.
+type LogContext struct {
+	Source              LogSource
+	App                 string
+	TraceID             string
+	ReferenceEntity     string
+	ReferenceRecordID   int64
+	ReferenceRecordName string
+	Actor               string
+	Metadata            map[string]any
+}
+
+// WithLogWriter attaches a LogWriter to ctx.
+func WithLogWriter(ctx context.Context, writer LogWriter) context.Context {
+	if ctx == nil || writer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, logWriterContextKey{}, writer)
+}
+
+// LogWriterFromContext returns the LogWriter attached to ctx.
+func LogWriterFromContext(ctx context.Context) (LogWriter, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	writer, ok := ctx.Value(logWriterContextKey{}).(LogWriter)
+	return writer, ok && writer != nil
+}
+
+// WithLogContext attaches runtime Log defaults to ctx.
+func WithLogContext(ctx context.Context, defaults LogContext) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	merged := LogContextFromContext(ctx)
+	merged = merged.with(defaults)
+	return context.WithValue(ctx, logContextKey{}, merged)
+}
+
+// LogContextFromContext returns the Log defaults attached to ctx.
+func LogContextFromContext(ctx context.Context) LogContext {
+	if ctx == nil {
+		return LogContext{}
+	}
+	defaults, _ := ctx.Value(logContextKey{}).(LogContext)
+	return defaults
+}
+
+// Debug writes a best-effort Debug Log.
+func Debug(ctx context.Context, title string, options ...LogOption) {
+	writeBestEffort(ctx, TypeDebug, title, "", options...)
+}
+
+// Info writes a best-effort Info Log.
+func Info(ctx context.Context, title string, options ...LogOption) {
+	writeBestEffort(ctx, TypeInfo, title, "", options...)
+}
+
+// Warning writes a best-effort Warning Log.
+func Warning(ctx context.Context, title string, options ...LogOption) {
+	writeBestEffort(ctx, TypeWarning, title, "", options...)
+}
+
+// Error writes a best-effort Error Log.
+func Error(ctx context.Context, title string, err error, options ...LogOption) {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	writeBestEffort(ctx, TypeError, title, message, options...)
+}
+
+// Panic writes a best-effort Panic Log.
+func Panic(ctx context.Context, title string, recovered any, options ...LogOption) {
+	writeBestEffort(ctx, TypePanic, title, recoveredMessage(recovered), options...)
+}
+
+func writeBestEffort(ctx context.Context, logType LogType, title string, message string, options ...LogOption) {
+	entry := LogEntry{Type: logType, Title: title, Message: message}
+	applyLogOptions(&entry, options)
+	_ = Log(ctx, entry)
+}
+
+// Log writes one LogEntry and returns persistence errors to strict callers.
+func Log(ctx context.Context, entry LogEntry) error {
+	writer, ok := LogWriterFromContext(ctx)
+	if !ok {
+		return ErrLogWriterUnavailable
+	}
+	entry = entry.withContext(LogContextFromContext(ctx))
+	entry.normalize()
+	if entry.Type == "" {
+		return errors.New("dygo log type is required")
+	}
+	if entry.Title == "" {
+		return errors.New("dygo log title is required")
+	}
+	return writer.WriteLog(ctx, entry)
+}
+
+// LogOption customizes a helper-written LogEntry.
+type LogOption func(*LogEntry)
+
+// WithTraceID sets the Log trace ID.
+func WithTraceID(traceID string) LogOption {
+	return func(entry *LogEntry) {
+		entry.TraceID = strings.TrimSpace(traceID)
+	}
+}
+
+// WithReference sets a polymorphic Record reference by app, Entity, and Record ID.
+func WithReference(appName string, entity string, recordID int64) LogOption {
+	return func(entry *LogEntry) {
+		appName = strings.TrimSpace(appName)
+		entity = strings.TrimSpace(entity)
+		if appName != "" && entity != "" {
+			entry.ReferenceEntity = appName + "." + entity
+		}
+		entry.ReferenceRecordID = recordID
+	}
+}
+
+// WithReferenceName stores the related Record's name snapshot.
+func WithReferenceName(name string) LogOption {
+	return func(entry *LogEntry) {
+		entry.ReferenceRecordName = strings.TrimSpace(name)
+	}
+}
+
+// WithApp sets the producing app.
+func WithApp(appName string) LogOption {
+	return func(entry *LogEntry) {
+		entry.App = strings.TrimSpace(appName)
+	}
+}
+
+// WithSource sets the Log source.
+func WithSource(source LogSource) LogOption {
+	return func(entry *LogEntry) {
+		entry.Source = LogSource(strings.TrimSpace(string(source)))
+	}
+}
+
+// WithActor sets the actor user Record name.
+func WithActor(actor string) LogOption {
+	return func(entry *LogEntry) {
+		entry.Actor = strings.TrimSpace(actor)
+	}
+}
+
+// WithMessage sets the longer Log detail.
+func WithMessage(message string) LogOption {
+	return func(entry *LogEntry) {
+		entry.Message = strings.TrimSpace(message)
+	}
+}
+
+// WithMetadata adds one structured metadata value.
+func WithMetadata(key string, value any) LogOption {
+	return func(entry *LogEntry) {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return
+		}
+		if entry.Metadata == nil {
+			entry.Metadata = map[string]any{}
+		}
+		entry.Metadata[key] = value
+	}
+}
+
+func applyLogOptions(entry *LogEntry, options []LogOption) {
+	for _, option := range options {
+		if option != nil {
+			option(entry)
+		}
+	}
+}
+
+func (entry LogEntry) withContext(defaults LogContext) LogEntry {
+	if entry.Source == "" {
+		entry.Source = defaults.Source
+	}
+	if entry.App == "" {
+		entry.App = defaults.App
+	}
+	if entry.TraceID == "" {
+		entry.TraceID = defaults.TraceID
+	}
+	if entry.ReferenceEntity == "" {
+		entry.ReferenceEntity = defaults.ReferenceEntity
+	}
+	if entry.ReferenceRecordID == 0 {
+		entry.ReferenceRecordID = defaults.ReferenceRecordID
+	}
+	if entry.ReferenceRecordName == "" {
+		entry.ReferenceRecordName = defaults.ReferenceRecordName
+	}
+	if entry.Actor == "" {
+		entry.Actor = defaults.Actor
+	}
+	entry.Metadata = mergedMetadata(defaults.Metadata, entry.Metadata)
+	return entry
+}
+
+func (defaults LogContext) with(next LogContext) LogContext {
+	if next.Source != "" {
+		defaults.Source = next.Source
+	}
+	if next.App != "" {
+		defaults.App = next.App
+	}
+	if next.TraceID != "" {
+		defaults.TraceID = next.TraceID
+	}
+	if next.ReferenceEntity != "" {
+		defaults.ReferenceEntity = next.ReferenceEntity
+	}
+	if next.ReferenceRecordID != 0 {
+		defaults.ReferenceRecordID = next.ReferenceRecordID
+	}
+	if next.ReferenceRecordName != "" {
+		defaults.ReferenceRecordName = next.ReferenceRecordName
+	}
+	if next.Actor != "" {
+		defaults.Actor = next.Actor
+	}
+	defaults.Metadata = mergedMetadata(defaults.Metadata, next.Metadata)
+	return defaults
+}
+
+func (entry *LogEntry) normalize() {
+	entry.Source = LogSource(strings.TrimSpace(string(entry.Source)))
+	if entry.Source == "" {
+		entry.Source = SourceSDK
+	}
+	entry.Type = LogType(strings.TrimSpace(string(entry.Type)))
+	entry.App = strings.TrimSpace(entry.App)
+	entry.Title = strings.TrimSpace(entry.Title)
+	entry.Message = strings.TrimSpace(entry.Message)
+	entry.TraceID = strings.TrimSpace(entry.TraceID)
+	entry.ReferenceEntity = strings.TrimSpace(entry.ReferenceEntity)
+	entry.ReferenceRecordName = strings.TrimSpace(entry.ReferenceRecordName)
+	entry.Actor = strings.TrimSpace(entry.Actor)
+}
+
+func mergedMetadata(left map[string]any, right map[string]any) map[string]any {
+	if len(left) == 0 && len(right) == 0 {
+		return nil
+	}
+	merged := make(map[string]any, len(left)+len(right))
+	for key, value := range left {
+		merged[key] = value
+	}
+	for key, value := range right {
+		merged[key] = value
+	}
+	return merged
+}
+
+func recoveredMessage(recovered any) string {
+	if recovered == nil {
+		return ""
+	}
+	if err, ok := recovered.(error); ok {
+		return err.Error()
+	}
+	return strings.TrimSpace(fmt.Sprint(recovered))
+}

--- a/pkg/dygo/logs_test.go
+++ b/pkg/dygo/logs_test.go
@@ -1,0 +1,69 @@
+package dygo
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestLogMergesContextDefaults(t *testing.T) {
+	writer := &captureLogWriter{}
+	ctx := WithLogWriter(context.Background(), writer)
+	ctx = WithLogContext(ctx, LogContext{
+		Source:              SourceHook,
+		App:                 "crm",
+		TraceID:             "trace-1",
+		ReferenceEntity:     "crm.customer",
+		ReferenceRecordID:   42,
+		ReferenceRecordName: "CUST-42",
+		Actor:               "admin@example.com",
+		Metadata:            map[string]any{"hook": "after-create"},
+	})
+
+	if err := Log(ctx, LogEntry{
+		Type:     TypeInfo,
+		Title:    "Customer import started",
+		Metadata: map[string]any{"batch": "May"},
+	}); err != nil {
+		t.Fatalf("Log() error = %v, want nil", err)
+	}
+
+	entry := writer.entry
+	if entry.Type != TypeInfo || entry.Source != SourceHook || entry.App != "crm" || entry.Title != "Customer import started" {
+		t.Fatalf("entry core fields = %+v, want context defaults and explicit title/type", entry)
+	}
+	if entry.TraceID != "trace-1" || entry.ReferenceEntity != "crm.customer" || entry.ReferenceRecordID != 42 || entry.ReferenceRecordName != "CUST-42" || entry.Actor != "admin@example.com" {
+		t.Fatalf("entry context fields = %+v, want defaults", entry)
+	}
+	if entry.Metadata["hook"] != "after-create" || entry.Metadata["batch"] != "May" {
+		t.Fatalf("entry metadata = %#v, want merged metadata", entry.Metadata)
+	}
+}
+
+func TestErrorHelperWritesErrorMessageBestEffort(t *testing.T) {
+	writer := &captureLogWriter{}
+	ctx := WithLogWriter(context.Background(), writer)
+
+	Error(ctx, "Customer import failed", errors.New("stripe timeout"))
+
+	entry := writer.entry
+	if entry.Type != TypeError || entry.Source != SourceSDK || entry.Title != "Customer import failed" || entry.Message != "stripe timeout" {
+		t.Fatalf("entry = %+v, want error helper fields", entry)
+	}
+}
+
+func TestLogWithoutWriterReturnsUnavailable(t *testing.T) {
+	err := Log(context.Background(), LogEntry{Type: TypeInfo, Title: "Started"})
+	if !errors.Is(err, ErrLogWriterUnavailable) {
+		t.Fatalf("Log() error = %v, want ErrLogWriterUnavailable", err)
+	}
+}
+
+type captureLogWriter struct {
+	entry LogEntry
+}
+
+func (w *captureLogWriter) WriteLog(_ context.Context, entry LogEntry) error {
+	w.entry = entry
+	return nil
+}

--- a/pkg/dygo/runtime/runtime.go
+++ b/pkg/dygo/runtime/runtime.go
@@ -6,13 +6,13 @@ import (
 	"io"
 
 	"github.com/hapyco/dygo/internal/cli"
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 // Options configures the compiled dygo runtime.
 type Options struct {
-	RecordHooks []sdk.RecordHookRegistrar
-	Jobs        []sdk.JobRegistrar
+	RecordHooks []dygo.RecordHookRegistrar
+	Jobs        []dygo.JobRegistrar
 }
 
 // Run executes the dygo CLI with compiled app extensions.

--- a/pkg/dygo/runtime/runtime_test.go
+++ b/pkg/dygo/runtime/runtime_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hapyco/dygo/pkg/sdk"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 func TestRunAppliesRecordHookRegistrars(t *testing.T) {
@@ -16,8 +16,8 @@ func TestRunAppliesRecordHookRegistrars(t *testing.T) {
 	called := false
 	var stdout bytes.Buffer
 	err := Run(context.Background(), []string{"version"}, strings.NewReader(""), &stdout, &bytes.Buffer{}, Options{
-		RecordHooks: []sdk.RecordHookRegistrar{
-			func(sdk.RecordHookRegistry) error {
+		RecordHooks: []dygo.RecordHookRegistrar{
+			func(dygo.RecordHookRegistry) error {
 				called = true
 				return nil
 			},
@@ -38,8 +38,8 @@ func TestRunReturnsRecordHookRegistrarErrors(t *testing.T) {
 	t.Parallel()
 
 	err := Run(context.Background(), []string{"version"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, Options{
-		RecordHooks: []sdk.RecordHookRegistrar{
-			func(sdk.RecordHookRegistry) error {
+		RecordHooks: []dygo.RecordHookRegistrar{
+			func(dygo.RecordHookRegistry) error {
 				return errors.New("boom")
 			},
 		},
@@ -56,8 +56,8 @@ func TestRunReturnsJobRegistrarErrors(t *testing.T) {
 	t.Parallel()
 
 	err := Run(context.Background(), []string{"version"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, Options{
-		Jobs: []sdk.JobRegistrar{
-			func(sdk.JobRegistry) error {
+		Jobs: []dygo.JobRegistrar{
+			func(dygo.JobRegistry) error {
 				return errors.New("boom")
 			},
 		},


### PR DESCRIPTION
## Summary

- Renames the public Go SDK package/import path from `pkg/sdk` to `pkg/dygo` with no compatibility shim.
- Adds the Core `log` Entity plus persisted logging helpers: `dygo.Debug`, `dygo.Info`, `dygo.Warning`, `dygo.Error`, `dygo.Panic`, and strict `dygo.Log`.
- Wires metadata-backed Log persistence through internal dygo data adapters and dogfoods it for recovered Job handler panics.
- Updates generators, runner wiring, docs, and follow-up TODOs for the new SDK/logging direction.

## Validation

- `go test ./...`
- `git diff --check`
- Searched for stale `pkg/sdk`, `package sdk`, `sdk.`, and `sdkdata` references.