### PR TITLE
Add Studio dialog foundation

### DIFF
--- a/apps/studio/ui/src/app/App.vue
+++ b/apps/studio/ui/src/app/App.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { computed, watch, type Component } from 'vue'
+import { computed, onUnmounted, watch, type Component } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import * as LucideIcons from '@lucide/vue'
 
+import DialogHost from '@/features/dialogs/DialogHost.vue'
+import { useDialog } from '@/features/dialogs/use-dialog'
+import { setAPIDialogHandler } from '@/features/api/client'
 import { routeParam, RouteName } from '@/router/routes'
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
 import Shell from '@/shell/Shell.vue'
@@ -14,6 +17,14 @@ import { storeError } from '@/stores/status'
 const route = useRoute()
 const authStore = useAuthStore()
 const navigationStore = useNavigationStore()
+const dialog = useDialog()
+
+setAPIDialogHandler((request) => {
+  void dialog.open(request)
+})
+onUnmounted(() => {
+  setAPIDialogHandler(null)
+})
 
 const usesShell = computed(() => !route.meta.public)
 const publicRouteViewKey = computed(() => `${route.fullPath}:${navigationStore.routeReloadVersion}`)
@@ -125,6 +136,7 @@ function humanizeEntity(value: string): string {
 
     <RouterView :key="shellRouteViewKey" />
   </Shell>
+  <DialogHost />
 </template>
 
 <style scoped>

--- a/apps/studio/ui/src/app/App.vue
+++ b/apps/studio/ui/src/app/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { computed, onUnmounted, watch, type Component } from 'vue'
+import { computed, onUnmounted, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
-import * as LucideIcons from '@lucide/vue'
 
 import DialogHost from '@/features/dialogs/DialogHost.vue'
 import { useDialog } from '@/features/dialogs/use-dialog'
 import { setAPIDialogHandler } from '@/features/api/client'
+import { iconForEntity } from '@/features/metadata/entity-icons'
 import { routeParam, RouteName } from '@/router/routes'
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
 import Shell from '@/shell/Shell.vue'
@@ -47,9 +47,6 @@ const metadataEntitiesError = computed(() => (
     ? storeError(metadataEntitiesQuery.error.value, 'Studio could not load entities.')
     : null
 ))
-
-const lucideIconRegistry = LucideIcons as unknown as Record<string, Component | undefined>
-const fallbackEntityIcon = LucideIcons.Box as Component
 
 const navItems = computed<ShellNavItem[]>(() => {
   return metadataEntities.value
@@ -93,23 +90,6 @@ function isEntityRoute(entity: string): boolean {
   }
 
   return currentEntity.value === entity
-}
-
-function iconForEntity(icon?: string): Component {
-  const key = icon?.trim()
-  if (!key) {
-    return fallbackEntityIcon
-  }
-
-  return lucideIconRegistry[key] ?? lucideIconRegistry[toPascalIconName(key)] ?? fallbackEntityIcon
-}
-
-function toPascalIconName(value: string): string {
-  return value
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join('')
 }
 
 function humanizeEntity(value: string): string {

--- a/apps/studio/ui/src/design/atoms/Button.vue
+++ b/apps/studio/ui/src/design/atoms/Button.vue
@@ -4,7 +4,7 @@ import type { ControlSize } from '../types'
 withDefaults(
   defineProps<{
     type?: 'button' | 'submit' | 'reset'
-    variant?: 'primary' | 'secondary' | 'ghost'
+    variant?: 'primary' | 'secondary' | 'ghost' | 'danger'
     size?: ControlSize
     loading?: boolean
     disabled?: boolean
@@ -103,6 +103,15 @@ withDefaults(
 .d-button--ghost:hover:not(:disabled) {
   background: var(--studio-surface-raised);
   color: var(--studio-text);
+}
+
+.d-button--danger {
+  background: var(--studio-danger);
+  color: oklch(0.99 0.004 246);
+}
+
+.d-button--danger:hover:not(:disabled) {
+  background: oklch(48% 0.16 28);
 }
 
 .d-button__spinner {

--- a/apps/studio/ui/src/features/api/client.test.ts
+++ b/apps/studio/ui/src/features/api/client.test.ts
@@ -54,6 +54,26 @@ test('apiRequest emits successful response dialogs', async (t) => {
   assert.equal(observedTitle, 'Saved')
 })
 
+test('apiRequest ignores dialog handler failures on successful responses', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => {
+    globalThis.fetch = originalFetch
+    setAPIDialogHandler(null)
+  })
+
+  setAPIDialogHandler(() => {
+    throw new Error('dialog failed')
+  })
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    data: { ok: true },
+    dialog: { title: 'Saved' },
+  }), { status: 200 })) as typeof fetch
+
+  const payload = await apiRequest<DataEnvelope<{ ok: boolean }>, TestApiError>('/api/test', { method: 'GET' }, requestOptions())
+
+  assert.deepEqual(payload.data, { ok: true })
+})
+
 test('apiRequest maps error envelopes through the domain error class', async (t) => {
   const originalFetch = globalThis.fetch
   t.after(() => {
@@ -104,6 +124,35 @@ test('apiRequest emits error response dialogs before throwing', async (t) => {
     TestApiError,
   )
   assert.equal(observedTitle, 'Access denied')
+})
+
+test('apiRequest preserves mapped errors when dialog handler fails', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => {
+    globalThis.fetch = originalFetch
+    setAPIDialogHandler(null)
+  })
+
+  setAPIDialogHandler(() => {
+    throw new Error('dialog failed')
+  })
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    error: {
+      code: 'forbidden',
+      message: 'permission denied',
+      dialog: { title: 'Access denied' },
+    },
+  }), { status: 403 })) as typeof fetch
+
+  await assert.rejects(
+    apiRequest<DataEnvelope<unknown>, TestApiError>('/api/test', { method: 'GET' }, requestOptions()),
+    (error) => {
+      assert.equal(error instanceof TestApiError, true)
+      assert.equal((error as TestApiError).code, 'forbidden')
+      assert.equal((error as Error).message, 'mapped: permission denied')
+      return true
+    },
+  )
 })
 
 test('apiRequest reports invalid JSON with the domain error class', async (t) => {

--- a/apps/studio/ui/src/features/api/client.test.ts
+++ b/apps/studio/ui/src/features/api/client.test.ts
@@ -1,7 +1,13 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { ApiClientError, apiRequest, type ApiErrorEnvelope, type DataEnvelope } from './client.ts'
+import {
+  ApiClientError,
+  apiRequest,
+  setAPIDialogHandler,
+  type ApiErrorEnvelope,
+  type DataEnvelope,
+} from './client.ts'
 
 class TestApiError extends ApiClientError {
   constructor(code: string, message: string, details?: Record<string, unknown>) {
@@ -25,6 +31,27 @@ test('apiRequest applies credentials and returns successful envelopes', async (t
 
   assert.deepEqual(payload.data, { ok: true })
   assert.equal(observedCredentials, 'include')
+})
+
+test('apiRequest emits successful response dialogs', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => {
+    globalThis.fetch = originalFetch
+    setAPIDialogHandler(null)
+  })
+
+  let observedTitle = ''
+  setAPIDialogHandler((dialog) => {
+    observedTitle = dialog.title
+  })
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    data: { ok: true },
+    dialog: { title: 'Saved' },
+  }), { status: 200 })) as typeof fetch
+
+  await apiRequest<DataEnvelope<{ ok: boolean }>, TestApiError>('/api/test', { method: 'GET' }, requestOptions())
+
+  assert.equal(observedTitle, 'Saved')
 })
 
 test('apiRequest maps error envelopes through the domain error class', async (t) => {
@@ -51,6 +78,32 @@ test('apiRequest maps error envelopes through the domain error class', async (t)
       return true
     },
   )
+})
+
+test('apiRequest emits error response dialogs before throwing', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => {
+    globalThis.fetch = originalFetch
+    setAPIDialogHandler(null)
+  })
+
+  let observedTitle = ''
+  setAPIDialogHandler((dialog) => {
+    observedTitle = dialog.title
+  })
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    error: {
+      code: 'forbidden',
+      message: 'permission denied',
+      dialog: { title: 'Access denied' },
+    },
+  }), { status: 403 })) as typeof fetch
+
+  await assert.rejects(
+    apiRequest<DataEnvelope<unknown>, TestApiError>('/api/test', { method: 'GET' }, requestOptions()),
+    TestApiError,
+  )
+  assert.equal(observedTitle, 'Access denied')
 })
 
 test('apiRequest reports invalid JSON with the domain error class', async (t) => {

--- a/apps/studio/ui/src/features/api/client.ts
+++ b/apps/studio/ui/src/features/api/client.ts
@@ -77,7 +77,11 @@ export async function apiRequest<TEnvelope, TError extends ApiClientError>(
 
 function emitAPIDialog(dialog: StudioDialogRequest | undefined) {
   if (dialog) {
-    apiDialogHandler?.({ ...dialog, source: 'server' })
+    try {
+      apiDialogHandler?.({ ...dialog, source: 'server' })
+    } catch {
+      // Dialog rendering is best-effort; it must not change API request semantics.
+    }
   }
 }
 

--- a/apps/studio/ui/src/features/api/client.ts
+++ b/apps/studio/ui/src/features/api/client.ts
@@ -1,7 +1,18 @@
+import type { StudioDialogRequest } from '../dialogs/dialogs.store'
+
+export type APIDialogHandler = (dialog: StudioDialogRequest) => void
+
+let apiDialogHandler: APIDialogHandler | null = null
+
+export function setAPIDialogHandler(handler: APIDialogHandler | null) {
+  apiDialogHandler = handler
+}
+
 export type ApiErrorBody = {
   code?: string
   message?: string
   details?: Record<string, unknown>
+  dialog?: StudioDialogRequest
 }
 
 export type ApiErrorEnvelope = {
@@ -10,11 +21,13 @@ export type ApiErrorEnvelope = {
 
 export type DataEnvelope<T> = {
   data: T
+  dialog?: StudioDialogRequest
 }
 
 export type ListEnvelope<T, M = unknown> = {
   data: T
   meta: M
+  dialog?: StudioDialogRequest
 }
 
 export class ApiClientError extends Error {
@@ -54,10 +67,18 @@ export async function apiRequest<TEnvelope, TError extends ApiClientError>(
   const payload = await parseAPIJSON<TEnvelope & ApiErrorEnvelope>(response, options.error, options.invalidResponseMessage)
 
   if (!response.ok) {
+    emitAPIDialog(payload.error?.dialog)
     throw new options.error(payload.error?.code ?? options.fallbackCode, options.message(payload), payload.error?.details)
   }
 
+  emitAPIDialog((payload as TEnvelope & { dialog?: StudioDialogRequest }).dialog)
   return payload
+}
+
+function emitAPIDialog(dialog: StudioDialogRequest | undefined) {
+  if (dialog) {
+    apiDialogHandler?.({ ...dialog, source: 'server' })
+  }
 }
 
 async function parseAPIJSON<TEnvelope, TError extends ApiClientError = ApiClientError>(

--- a/apps/studio/ui/src/features/dialogs/DialogHost.vue
+++ b/apps/studio/ui/src/features/dialogs/DialogHost.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+  DialogTitle,
+} from 'reka-ui'
+
+import { Button } from '@/design'
+import { useDialogStore, type StudioDialog, type StudioDialogActionVariant } from './dialogs.store'
+
+const dialogStore = useDialogStore()
+const topDialog = computed(() => dialogStore.topDialog)
+
+function onOpenChange(open: boolean) {
+  if (!open) {
+    dialogStore.dismissTop()
+  }
+}
+
+function preventOutside(event: Event) {
+  event.preventDefault()
+}
+
+function preventEscapeWhenRequired(event: Event) {
+  if (!topDialog.value?.dismissible) {
+    event.preventDefault()
+  }
+}
+
+function choose(dialog: StudioDialog, key: string) {
+  dialogStore.selectAction(dialog.id, key)
+}
+
+function buttonVariant(variant: StudioDialogActionVariant): 'primary' | 'secondary' | 'danger' {
+  return variant === 'danger' ? 'danger' : variant
+}
+</script>
+
+<template>
+  <DialogRoot :open="Boolean(topDialog)" modal @update:open="onOpenChange">
+    <DialogPortal v-if="topDialog">
+      <DialogOverlay class="studio-dialog__overlay" />
+      <DialogContent
+        class="studio-dialog"
+        :data-type="topDialog.type"
+        @escape-key-down="preventEscapeWhenRequired"
+        @pointer-down-outside="preventOutside"
+        @interact-outside="preventOutside"
+      >
+        <DialogTitle class="studio-dialog__title">
+          {{ topDialog.title }}
+        </DialogTitle>
+        <DialogDescription v-if="topDialog.content" class="studio-dialog__content">
+          {{ topDialog.content }}
+        </DialogDescription>
+        <div class="studio-dialog__actions">
+          <Button
+            v-for="action in topDialog.actions"
+            :key="action.key"
+            :variant="buttonVariant(action.variant)"
+            size="sm"
+            @click="choose(topDialog, action.key)"
+          >
+            {{ action.label }}
+          </Button>
+        </div>
+      </DialogContent>
+    </DialogPortal>
+  </DialogRoot>
+</template>
+
+<style scoped>
+.studio-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: oklch(18% 0.02 246 / 0.34);
+}
+
+.studio-dialog {
+  position: fixed;
+  z-index: 81;
+  top: 50%;
+  left: 50%;
+  width: min(calc(100vw - 32px), 420px);
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--studio-border);
+  border-radius: var(--studio-radius-sheet);
+  background: var(--studio-surface);
+  box-shadow: var(--studio-shadow);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.studio-dialog:focus-visible {
+  outline: 2px solid var(--studio-focus);
+  outline-offset: 2px;
+}
+
+.studio-dialog__title {
+  color: var(--studio-text);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.studio-dialog__content {
+  color: var(--studio-text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.studio-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 4px;
+}
+</style>

--- a/apps/studio/ui/src/features/dialogs/dialogs.store.test.ts
+++ b/apps/studio/ui/src/features/dialogs/dialogs.store.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useDialogStore } from './dialogs.store.ts'
+
+test('dialog store defaults dismissible dialogs', async () => {
+  setActivePinia(createPinia())
+  const store = useDialogStore()
+
+  const result = store.open({ title: 'Saved' })
+  const dialog = store.topDialog
+  assert.equal(dialog?.type, 'neutral')
+  assert.equal(dialog?.dismissible, true)
+  assert.deepEqual(dialog?.actions, [{ key: 'ok', label: 'OK', variant: 'primary' }])
+
+  store.selectAction(dialog?.id ?? 0, 'ok')
+  assert.equal(await result, 'ok')
+})
+
+test('dialog store rejects non-dismissible dialogs without actions', () => {
+  setActivePinia(createPinia())
+  const store = useDialogStore()
+
+  assert.throws(
+    () => store.open({ title: 'Required', dismissible: false }),
+    /requires an action/,
+  )
+})
+
+test('dialog store rejects duplicate action keys', () => {
+  setActivePinia(createPinia())
+  const store = useDialogStore()
+
+  assert.throws(
+    () => store.open({
+      title: 'Choose',
+      actions: [
+        { key: 'same', label: 'First' },
+        { key: 'same', label: 'Second' },
+      ],
+    }),
+    /duplicate dialog action key/,
+  )
+})
+
+test('dialog store resolves the top dialog independently', async () => {
+  setActivePinia(createPinia())
+  const store = useDialogStore()
+
+  const first = store.open({ title: 'First' })
+  const firstID = store.topDialog?.id ?? 0
+  const second = store.open({ title: 'Second' })
+  const secondID = store.topDialog?.id ?? 0
+
+  assert.equal(store.topDialog?.title, 'Second')
+  store.selectAction(secondID, 'ok')
+  assert.equal(await second, 'ok')
+
+  assert.equal(store.topDialog?.title, 'First')
+  store.dismissTop()
+  assert.equal(await first, null)
+  assert.equal(store.stack.length, 0)
+  assert.notEqual(firstID, secondID)
+})

--- a/apps/studio/ui/src/features/dialogs/dialogs.store.ts
+++ b/apps/studio/ui/src/features/dialogs/dialogs.store.ts
@@ -1,0 +1,132 @@
+import { defineStore } from 'pinia'
+
+export type StudioDialogType = 'neutral' | 'info' | 'success' | 'warning' | 'danger'
+export type StudioDialogActionVariant = 'primary' | 'secondary' | 'danger'
+export type StudioDialogSource = 'client' | 'server'
+export type StudioDialogResult = string | null
+
+export type StudioDialogAction = {
+  key: string
+  label: string
+  variant?: StudioDialogActionVariant
+}
+
+export type StudioDialogRequest = {
+  title: string
+  content?: string
+  type?: StudioDialogType
+  actions?: StudioDialogAction[]
+  dismissible?: boolean
+  source?: StudioDialogSource
+}
+
+export type StudioDialog = {
+  id: number
+  title: string
+  content: string
+  type: StudioDialogType
+  actions: Required<StudioDialogAction>[]
+  dismissible: boolean
+  source: StudioDialogSource
+}
+
+let nextDialogID = 1
+const resolvers = new Map<number, (result: StudioDialogResult) => void>()
+
+export const useDialogStore = defineStore('dialogs', {
+  state: () => ({
+    stack: [] as StudioDialog[],
+  }),
+
+  getters: {
+    topDialog: (state): StudioDialog | null => state.stack.at(-1) ?? null,
+  },
+
+  actions: {
+    open(request: StudioDialogRequest): Promise<StudioDialogResult> {
+      const dialog = normalizeDialog(request)
+      this.stack.push(dialog)
+
+      return new Promise((resolve) => {
+        resolvers.set(dialog.id, resolve)
+      })
+    },
+
+    selectAction(id: number, key: string) {
+      const dialog = this.topDialog
+      if (!dialog || dialog.id !== id || !dialog.actions.some((action) => action.key === key)) {
+        return
+      }
+
+      this.closeTop(key)
+    },
+
+    dismissTop() {
+      if (!this.topDialog?.dismissible) {
+        return
+      }
+
+      this.closeTop(null)
+    },
+
+    closeTop(result: StudioDialogResult) {
+      const dialog = this.topDialog
+      if (!dialog) {
+        return
+      }
+
+      this.stack.pop()
+      resolvers.get(dialog.id)?.(result)
+      resolvers.delete(dialog.id)
+    },
+  },
+})
+
+function normalizeDialog(request: StudioDialogRequest): StudioDialog {
+  const title = request.title.trim()
+  if (!title) {
+    throw new Error('dialog title is required')
+  }
+
+  const dismissible = request.dismissible ?? true
+  const actions = normalizeActions(request.actions)
+  if (actions.length === 0) {
+    if (!dismissible) {
+      throw new Error('non-dismissible dialog requires an action')
+    }
+    actions.push({ key: 'ok', label: 'OK', variant: 'primary' })
+  }
+
+  return {
+    id: nextDialogID++,
+    title,
+    content: request.content?.trim() ?? '',
+    type: request.type ?? 'neutral',
+    actions,
+    dismissible,
+    source: request.source ?? 'client',
+  }
+}
+
+function normalizeActions(actions: StudioDialogAction[] | undefined): Required<StudioDialogAction>[] {
+  const normalized: Required<StudioDialogAction>[] = []
+  const keys = new Set<string>()
+
+  for (const action of actions ?? []) {
+    const key = action.key.trim()
+    const label = action.label.trim()
+    if (!key) {
+      throw new Error('dialog action key is required')
+    }
+    if (!label) {
+      throw new Error('dialog action label is required')
+    }
+    if (keys.has(key)) {
+      throw new Error(`duplicate dialog action key: ${key}`)
+    }
+    keys.add(key)
+    normalized.push({ key, label, variant: action.variant ?? 'secondary' })
+  }
+
+  return normalized
+}

--- a/apps/studio/ui/src/features/dialogs/use-dialog.ts
+++ b/apps/studio/ui/src/features/dialogs/use-dialog.ts
@@ -1,0 +1,24 @@
+import { useDialogStore, type StudioDialogRequest, type StudioDialogResult } from './dialogs.store'
+
+export function useDialog() {
+  const store = useDialogStore()
+
+  return {
+    open: (request: StudioDialogRequest): Promise<StudioDialogResult> => store.open(request),
+    alert: (request: StudioDialogRequest): Promise<StudioDialogResult> => store.open({
+      ...request,
+      actions: request.actions ?? [{ key: 'ok', label: 'OK', variant: 'primary' }],
+    }),
+    confirm: (request: StudioDialogRequest): Promise<StudioDialogResult> => store.open({
+      ...request,
+      dismissible: request.dismissible ?? false,
+      actions: request.actions ?? [
+        { key: 'cancel', label: 'Cancel', variant: 'secondary' },
+        { key: 'confirm', label: 'Confirm', variant: 'primary' },
+      ],
+    }),
+    choose: (request: StudioDialogRequest): Promise<StudioDialogResult> => store.open(request),
+  }
+}
+
+export type { StudioDialogRequest, StudioDialogResult }

--- a/apps/studio/ui/src/features/metadata/entity-icons.test.ts
+++ b/apps/studio/ui/src/features/metadata/entity-icons.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { Box, Settings2 } from '@lucide/vue'
+
+import { iconForEntity } from './entity-icons.ts'
+
+test('iconForEntity resolves metadata icon names without bundling all Lucide icons', () => {
+  assert.equal(iconForEntity('settings-2'), Settings2)
+  assert.equal(iconForEntity('Settings2'), Settings2)
+  assert.equal(iconForEntity('missing-icon'), Box)
+})

--- a/apps/studio/ui/src/features/metadata/entity-icons.ts
+++ b/apps/studio/ui/src/features/metadata/entity-icons.ts
@@ -1,0 +1,64 @@
+import type { Component } from 'vue'
+import {
+  Activity,
+  Box,
+  Boxes,
+  BriefcaseBusiness,
+  CalendarClock,
+  CircleDollarSign,
+  Clock,
+  Columns3,
+  FileText,
+  Flag,
+  GitPullRequestArrow,
+  Hash,
+  KeyRound,
+  Languages,
+  ListChecks,
+  ListTree,
+  Package,
+  Settings2,
+  Shield,
+  ShieldCheck,
+  User,
+  UsersRound,
+} from '@lucide/vue'
+
+const entityIconRegistry: Record<string, Component> = {
+  activity: Activity,
+  box: Box,
+  boxes: Boxes,
+  'briefcase-business': BriefcaseBusiness,
+  'calendar-clock': CalendarClock,
+  'circle-dollar-sign': CircleDollarSign,
+  clock: Clock,
+  'columns-3': Columns3,
+  'file-text': FileText,
+  flag: Flag,
+  'git-pull-request-arrow': GitPullRequestArrow,
+  hash: Hash,
+  'key-round': KeyRound,
+  languages: Languages,
+  'list-checks': ListChecks,
+  'list-tree': ListTree,
+  package: Package,
+  'settings-2': Settings2,
+  shield: Shield,
+  'shield-check': ShieldCheck,
+  user: User,
+  'users-round': UsersRound,
+}
+
+export function iconForEntity(icon?: string): Component {
+  const key = icon ? toEntityIconKey(icon) : ''
+  return key ? entityIconRegistry[key] ?? Box : Box
+}
+
+function toEntityIconKey(value: string): string {
+  return value
+    .trim()
+    .replace(/[_\s]+/g, '-')
+    .replace(/([a-z])([A-Z0-9])/g, '$1-$2')
+    .replace(/([0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+}

--- a/apps/studio/ui/src/pages/RecordFormPage.vue
+++ b/apps/studio/ui/src/pages/RecordFormPage.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { Plus, RotateCcw, Save, Trash2 } from '@lucide/vue'
 
 import { ErrorState, Spinner } from '@/design'
+import { useDialog } from '@/features/dialogs/use-dialog'
 import type { MetadataEntityMeta, MetadataField } from '@/features/metadata/metadata.api'
 import { useMetadataEntityMetaQuery } from '@/features/metadata/metadata.query'
 import {
@@ -35,6 +36,7 @@ type ConvertedValue = {
 }
 
 const router = useRouter()
+const dialog = useDialog()
 const entityMetaQuery = useMetadataEntityMetaQuery(() => props.entity)
 
 const draft = ref<RecordData>({})
@@ -327,7 +329,16 @@ async function deleteRecord() {
   }
 
   const recordLabel = props.recordName || entityLabel.value
-  if (!window.confirm(`Delete ${recordLabel}? This cannot be undone.`)) {
+  const action = await dialog.confirm({
+    title: `Delete ${recordLabel}?`,
+    content: 'This cannot be undone.',
+    type: 'danger',
+    actions: [
+      { key: 'cancel', label: 'Cancel', variant: 'secondary' },
+      { key: 'confirm', label: 'Delete', variant: 'danger' },
+    ],
+  })
+  if (action !== 'confirm') {
     return
   }
 

--- a/apps/studio/ui/src/shell/CommandMenu.vue
+++ b/apps/studio/ui/src/shell/CommandMenu.vue
@@ -3,9 +3,7 @@ import { computed, nextTick, ref, watch, type Component } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRoute, useRouter, type RouteLocationNormalizedLoaded } from 'vue-router'
 import { onKeyStroke } from '@vueuse/core'
-import * as LucideIcons from '@lucide/vue'
 import {
-  Box,
   Clock,
   Command,
   FilePlus2,
@@ -17,6 +15,7 @@ import {
 
 import { queryClient } from '@/app/query'
 import { reloadStudioApp } from '@/app/reload'
+import { iconForEntity } from '@/features/metadata/entity-icons'
 import type { MetadataEntity } from '@/features/metadata/metadata.api'
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
 import { routeParam, RouteName } from '@/router/routes'
@@ -51,7 +50,6 @@ const searchInput = ref<HTMLInputElement | null>(null)
 const query = ref('')
 const activeItemId = ref('')
 const runningAppAction = ref(false)
-const lucideIconRegistry = LucideIcons as unknown as Record<string, Component | undefined>
 const metadataEntitiesQuery = useMetadataEntitiesQuery({
   enabled: computed(() => Boolean(authStore.currentUser)),
 })
@@ -369,23 +367,6 @@ function normalizeHome(value: unknown): string {
 
 function entityLabel(entity: MetadataEntity): string {
   return entity.label || humanizeEntity(entity.slug ?? entity.key)
-}
-
-function iconForEntity(icon?: string): Component {
-  const key = icon?.trim()
-  if (!key) {
-    return Box
-  }
-
-  return lucideIconRegistry[key] ?? lucideIconRegistry[toPascalIconName(key)] ?? Box
-}
-
-function toPascalIconName(value: string): string {
-  return value
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join('')
 }
 
 function humanizeEntity(value: string): string {

--- a/docs/dialogs.md
+++ b/docs/dialogs.md
@@ -28,9 +28,15 @@ Studio needs one shared dialog surface for framework flows, metadata-driven acti
 - Dialog requests require `title`.
 - Dialog requests may include `content`, `type`, `actions`, and `dismissible`.
 - Dialog requests always have props; v1 props are `title`, `content`, `type`, `actions`, `dismissible`, and `source`.
+- `type` defaults to `neutral`.
+- `dismissible` defaults to `true`.
+- `actions` defaults to one `ok` primary action when no actions are supplied.
 - `dismissible` controls whether the user can close the dialog without choosing an action.
 - Non-dismissible dialogs must include at least one action.
 - Dialogs may include multiple actions.
+- Action keys must be non-empty.
+- Action labels must be non-empty.
+- Action keys must be unique inside one dialog.
 - `content` is plain text in v1.
 - Do not allow raw HTML content in v1.
 - Do not add app-defined custom dialog components in v1.
@@ -46,7 +52,9 @@ Studio needs one shared dialog surface for framework flows, metadata-driven acti
 - Only the top dialog is interactive.
 - Closing the top dialog reveals the previous dialog.
 - Dialog calls resolve only when their own dialog closes.
+- `useDialog()` resolves to the selected action key, or `null` when a dismissible dialog is dismissed.
 - Escape only affects the top dismissible dialog.
+- Backdrop click does not dismiss dialogs in v1.
 - Server-driven dialogs use the same stack as client-created dialogs.
 - Do not auto-dedupe dialogs in v1.
 - Dialogs must trap focus, support Escape when dismissible, and restore focus after close.
@@ -54,6 +62,9 @@ Studio needs one shared dialog surface for framework flows, metadata-driven acti
 - Access gate failures can use the shared dialog API for "Access denied", "Session expired", and "Missing setup" states.
 - Server responses may include a dialog intent.
 - Server errors may include a dialog intent.
+- Success responses put `dialog` beside `data`.
+- Error responses put `dialog` inside the existing `error` envelope.
+- Confirmation tokens live in `error.details.confirmationToken`.
 - The server returns dialog data; Studio decides how to render it.
 - Server dialog intents cannot include raw HTML.
 - Server dialog intents cannot include JavaScript callbacks.
@@ -82,20 +93,57 @@ type StudioDialogRequest = {
   source?: "client" | "server"
 }
 
+type StudioDialogResult = string | null
+
 type StudioAPIResponse<T> = {
   data?: T
   dialog?: StudioDialogRequest
 }
 
-type StudioAPIError = {
+type StudioAPIErrorBody = {
   code: string
   message: string
+  details?: Record<string, unknown>
   dialog?: StudioDialogRequest
 }
 
-type StudioConfirmationRequired = {
-  code: "confirmation_required"
-  confirmationToken: string
-  dialog: StudioDialogRequest
+type StudioAPIErrorEnvelope = {
+  error: StudioAPIErrorBody
+}
+```
+
+## SDK Shape
+
+```go
+type DialogType string
+
+const (
+	DialogNeutral DialogType = "neutral"
+	DialogInfo    DialogType = "info"
+	DialogSuccess DialogType = "success"
+	DialogWarning DialogType = "warning"
+	DialogDanger  DialogType = "danger"
+)
+
+type DialogActionVariant string
+
+const (
+	DialogActionPrimary   DialogActionVariant = "primary"
+	DialogActionSecondary DialogActionVariant = "secondary"
+	DialogActionDanger    DialogActionVariant = "danger"
+)
+
+type DialogAction struct {
+	Key     string              `json:"key"`
+	Label   string              `json:"label"`
+	Variant DialogActionVariant `json:"variant,omitempty"`
+}
+
+type Dialog struct {
+	Title       string         `json:"title"`
+	Content     string         `json:"content,omitempty"`
+	Type        DialogType     `json:"type,omitempty"`
+	Actions     []DialogAction `json:"actions,omitempty"`
+	Dismissible *bool          `json:"dismissible,omitempty"`
 }
 ```

--- a/docs/dialogs.md
+++ b/docs/dialogs.md
@@ -30,7 +30,7 @@ Studio needs one shared dialog surface for framework flows, metadata-driven acti
 - Dialog requests always have props; v1 props are `title`, `content`, `type`, `actions`, `dismissible`, and `source`.
 - `type` defaults to `neutral`.
 - `dismissible` defaults to `true`.
-- `actions` defaults to one `ok` primary action when no actions are supplied.
+- Dismissible dialogs default to one `ok` primary action when no actions are supplied.
 - `dismissible` controls whether the user can close the dialog without choosing an action.
 - Non-dismissible dialogs must include at least one action.
 - Dialogs may include multiple actions.

--- a/docs/dialogs.md
+++ b/docs/dialogs.md
@@ -12,6 +12,8 @@ Studio needs one shared dialog surface for framework flows, metadata-driven acti
 - Treat `popup` as an informal word, not an API name.
 - Dialogs are part of Studio shell, not individual pages.
 - Studio exposes one dialog API that pages, stores, and framework flows can call.
+- Use `useDialog()` as the frontend API name.
+- `useDialog()` exposes `open`, `alert`, `confirm`, and `choose`.
 - The first API should cover alert, confirm, and choice dialogs.
 - The API returns the selected action instead of mutating caller state directly.
 - Dialog actions are explicit objects with `key`, `label`, and optional `variant`.
@@ -32,6 +34,13 @@ Studio needs one shared dialog surface for framework flows, metadata-driven acti
 - `content` is plain text in v1.
 - Do not allow raw HTML content in v1.
 - Do not add app-defined custom dialog components in v1.
+- Non-blocking messages use a separate toast API.
+- Dialogs stay blocking.
+- Toasts are tracked separately in Roadmap item `#263`.
+- Do not model form-like dialogs in v1.
+- Form-like dialogs belong to future action or workflow forms.
+- Do not add dialog analytics or audit logging in v1.
+- Audit the operation, not the dialog.
 - Studio keeps a dialog stack.
 - New dialogs are pushed on top of the stack.
 - Only the top dialog is interactive.
@@ -90,10 +99,3 @@ type StudioConfirmationRequired = {
   dialog: StudioDialogRequest
 }
 ```
-
-## Pending
-
-- Decide exact frontend API name.
-- Decide whether non-blocking notifications need a separate `toast` API.
-- Decide how form-like dialogs should be modeled later.
-- Decide how dialog analytics or audit logging should work for sensitive actions.

--- a/docs/dialogs.md
+++ b/docs/dialogs.md
@@ -1,0 +1,99 @@
+# Dialogs
+
+Status: v1 implementation decision log.
+
+Studio needs one shared dialog surface for framework flows, metadata-driven actions, and app code that needs user confirmation.
+
+## Decided
+
+- Use `dialog` as the public Studio term.
+- Use `dygo.Dialog` as the public SDK type name.
+- Do not use `dygo.ThrowDialog` or `dygo.ShowDialog` as SDK type names.
+- Treat `popup` as an informal word, not an API name.
+- Dialogs are part of Studio shell, not individual pages.
+- Studio exposes one dialog API that pages, stores, and framework flows can call.
+- The first API should cover alert, confirm, and choice dialogs.
+- The API returns the selected action instead of mutating caller state directly.
+- Dialog actions are explicit objects with `key`, `label`, and optional `variant`.
+- Dialog actions do not execute methods directly.
+- Dialog actions return a selected `key`.
+- Client-created dialog callers decide what returned action keys mean.
+- Server-driven dialog action keys are sent back to the server with the confirmation token.
+- Do not put method names, callback names, or dotted action paths in dialog actions in v1.
+- Common action keys such as `ok`, `cancel`, `confirm`, `delete`, `retry`, and `continue` are conventions, not a fixed enum.
+- Supported action variants are `primary`, `secondary`, and `danger`.
+- Supported dialog types are `info`, `success`, `warning`, `danger`, and `neutral`.
+- Dialog requests require `title`.
+- Dialog requests may include `content`, `type`, `actions`, and `dismissible`.
+- Dialog requests always have props; v1 props are `title`, `content`, `type`, `actions`, `dismissible`, and `source`.
+- `dismissible` controls whether the user can close the dialog without choosing an action.
+- Non-dismissible dialogs must include at least one action.
+- Dialogs may include multiple actions.
+- `content` is plain text in v1.
+- Do not allow raw HTML content in v1.
+- Do not add app-defined custom dialog components in v1.
+- Studio keeps a dialog stack.
+- New dialogs are pushed on top of the stack.
+- Only the top dialog is interactive.
+- Closing the top dialog reveals the previous dialog.
+- Dialog calls resolve only when their own dialog closes.
+- Escape only affects the top dismissible dialog.
+- Server-driven dialogs use the same stack as client-created dialogs.
+- Do not auto-dedupe dialogs in v1.
+- Dialogs must trap focus, support Escape when dismissible, and restore focus after close.
+- Destructive actions must use the `danger` action variant.
+- Access gate failures can use the shared dialog API for "Access denied", "Session expired", and "Missing setup" states.
+- Server responses may include a dialog intent.
+- Server errors may include a dialog intent.
+- The server returns dialog data; Studio decides how to render it.
+- Server dialog intents cannot include raw HTML.
+- Server dialog intents cannot include JavaScript callbacks.
+- Server dialog actions return keys only.
+- Server confirmation-required flows must use a token and retry model.
+- Do not allow server dialog actions to force navigation in v1.
+
+## Shape
+
+```ts
+type StudioDialogType = "neutral" | "info" | "success" | "warning" | "danger"
+type StudioDialogActionVariant = "primary" | "secondary" | "danger"
+
+type StudioDialogAction = {
+  key: string
+  label: string
+  variant?: StudioDialogActionVariant
+}
+
+type StudioDialogRequest = {
+  title: string
+  content?: string
+  type?: StudioDialogType
+  actions?: StudioDialogAction[]
+  dismissible?: boolean
+  source?: "client" | "server"
+}
+
+type StudioAPIResponse<T> = {
+  data?: T
+  dialog?: StudioDialogRequest
+}
+
+type StudioAPIError = {
+  code: string
+  message: string
+  dialog?: StudioDialogRequest
+}
+
+type StudioConfirmationRequired = {
+  code: "confirmation_required"
+  confirmationToken: string
+  dialog: StudioDialogRequest
+}
+```
+
+## Pending
+
+- Decide exact frontend API name.
+- Decide whether non-blocking notifications need a separate `toast` API.
+- Decide how form-like dialogs should be modeled later.
+- Decide how dialog analytics or audit logging should work for sensitive actions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Use this index to find the right document for the task. The docs are kept in the
 ## Studio
 
 - [Studio](studio.md) explains the first-party global UI app, route model, and design responsibilities.
+- [Dialogs](dialogs.md) records the proposed shared Studio dialog API.
 
 ## Maintainers
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,7 +21,7 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #261 Make reserved names and fixture eligibility policies extendable by apps
 - [ ] #262 Design versioned metadata import and replacement behavior for duplicate authored Records
 - [ ] #33 Add site command group
-- [ ] #38 Add one-command local project setup
+- [x] #38 Add one-command local project setup
 - [ ] #51 Add Studio metadata browser
 - [ ] #65 Add secret field type
 - [ ] #68 Add account invitations and password recovery
@@ -93,6 +93,7 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #202 Add saved filters for Studio record lists
 - [ ] #246 Add Studio DOM freeze support
 - [ ] #247 Add Studio dialog and popup API
+- [ ] #263 Add Studio notification and toast API
 - [ ] #248 Design notification logic for system and external events
 - [ ] #249 Add test mode for trying changes before switching live
 - [ ] #250 Add Studio debug bar

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -92,7 +92,7 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #192 Support filtered Link field records
 - [ ] #202 Add saved filters for Studio record lists
 - [ ] #246 Add Studio DOM freeze support
-- [ ] #247 Add Studio dialog and popup API
+- [x] #247 Add Studio dialog and popup API
 - [ ] #263 Add Studio notification and toast API
 - [ ] #248 Design notification logic for system and external events
 - [ ] #249 Add test mode for trying changes before switching live

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hapyco/dygo/internal/permissions"
 	"github.com/hapyco/dygo/internal/recordquery"
 	"github.com/hapyco/dygo/internal/reserved"
+	"github.com/hapyco/dygo/pkg/dygo"
 )
 
 const shutdownTimeout = 5 * time.Second
@@ -425,7 +426,8 @@ func writeAuthError(w http.ResponseWriter, err error) {
 }
 
 type dataEnvelope struct {
-	Data any `json:"data"`
+	Data   any          `json:"data"`
+	Dialog *dygo.Dialog `json:"dialog,omitempty"`
 }
 
 type bootDefaults struct {
@@ -507,8 +509,9 @@ func normalizeBootHome(value any) string {
 }
 
 type listEnvelope struct {
-	Data any `json:"data"`
-	Meta any `json:"meta"`
+	Data   any          `json:"data"`
+	Meta   any          `json:"meta"`
+	Dialog *dygo.Dialog `json:"dialog,omitempty"`
 }
 
 type recordListMeta struct {
@@ -526,6 +529,7 @@ type apiError struct {
 	Code    string         `json:"code"`
 	Message string         `json:"message"`
 	Details map[string]any `json:"details,omitempty"`
+	Dialog  *dygo.Dialog   `json:"dialog,omitempty"`
 }
 
 func writeErrorEnvelope(w http.ResponseWriter, status int, code string, message string, details map[string]any) {

--- a/pkg/dygo/dialogs.go
+++ b/pkg/dygo/dialogs.go
@@ -1,0 +1,37 @@
+package dygo
+
+// DialogType controls the visual intent of a Studio dialog.
+type DialogType string
+
+const (
+	DialogNeutral DialogType = "neutral"
+	DialogInfo    DialogType = "info"
+	DialogSuccess DialogType = "success"
+	DialogWarning DialogType = "warning"
+	DialogDanger  DialogType = "danger"
+)
+
+// DialogActionVariant controls how a Studio dialog action is styled.
+type DialogActionVariant string
+
+const (
+	DialogActionPrimary   DialogActionVariant = "primary"
+	DialogActionSecondary DialogActionVariant = "secondary"
+	DialogActionDanger    DialogActionVariant = "danger"
+)
+
+// DialogAction is one user-selectable dialog action.
+type DialogAction struct {
+	Key     string              `json:"key"`
+	Label   string              `json:"label"`
+	Variant DialogActionVariant `json:"variant,omitempty"`
+}
+
+// Dialog is a server-provided Studio dialog intent.
+type Dialog struct {
+	Title       string         `json:"title"`
+	Content     string         `json:"content,omitempty"`
+	Type        DialogType     `json:"type,omitempty"`
+	Actions     []DialogAction `json:"actions,omitempty"`
+	Dismissible *bool          `json:"dismissible,omitempty"`
+}

--- a/pkg/dygo/dialogs_test.go
+++ b/pkg/dygo/dialogs_test.go
@@ -1,0 +1,27 @@
+package dygo
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDialogJSONIncludesExplicitFalseDismissible(t *testing.T) {
+	dismissible := false
+	data, err := json.Marshal(Dialog{
+		Title:       "Delete invoice?",
+		Dismissible: &dismissible,
+		Actions: []DialogAction{{
+			Key:     "confirm",
+			Label:   "Delete",
+			Variant: DialogActionDanger,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Marshal(Dialog) error = %v", err)
+	}
+
+	want := `{"title":"Delete invoice?","actions":[{"key":"confirm","label":"Delete","variant":"danger"}],"dismissible":false}`
+	if string(data) != want {
+		t.Fatalf("Dialog JSON = %s, want %s", data, want)
+	}
+}


### PR DESCRIPTION
Adds the Studio dialog API, server dialog envelope fields, delete confirmation dialog, docs, and trims the Studio icon bundle.\n\nVerified:\n- go test ./pkg/dygo ./internal/server\n- npm test --prefix apps/studio/ui\n- npm run build --prefix apps/studio/ui