### PR TITLE
feat: add theming and dark mode

### DIFF
--- a/apps/studio/ui/index.html
+++ b/apps/studio/ui/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>dygo Studio</title>
+    <script>
+      (function () {
+        var preference = 'system'
+        try {
+          var stored = window.localStorage.getItem('studio:theme')
+          preference = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system'
+        } catch {}
+
+        var prefersDark = false
+        try {
+          prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        } catch {}
+
+        var dark = preference === 'dark' || (preference === 'system' && prefersDark)
+        document.documentElement.dataset.theme = dark ? 'dark' : 'light'
+      })()
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/studio/ui/src/app/main.ts
+++ b/apps/studio/ui/src/app/main.ts
@@ -3,8 +3,11 @@ import { VueQueryPlugin } from '@tanstack/vue-query'
 
 import App from './App.vue'
 import { queryClient } from './query'
+import { installStudioTheme } from '@/features/theme'
 import { router } from '@/router'
 import { pinia } from '@/stores/pinia'
 import '@/styles/base.css'
+
+installStudioTheme()
 
 createApp(App).use(pinia).use(VueQueryPlugin, { queryClient }).use(router).mount('#app')

--- a/apps/studio/ui/src/design/atoms/Badge.vue
+++ b/apps/studio/ui/src/design/atoms/Badge.vue
@@ -37,31 +37,31 @@ withDefaults(defineProps<{
 }
 
 .d-badge--accent {
-  border-color: oklch(0.49 0.118 248 / 0.22);
+  border-color: var(--studio-accent-border);
   background: var(--studio-accent-soft);
   color: var(--studio-accent-strong);
 }
 
 .d-badge--success {
-  border-color: oklch(0.52 0.105 156 / 0.22);
+  border-color: var(--studio-success-border);
   background: var(--studio-success-soft);
   color: var(--studio-success);
 }
 
 .d-badge--warning {
-  border-color: oklch(0.63 0.13 74 / 0.26);
+  border-color: var(--studio-warning-border);
   background: var(--studio-warning-soft);
-  color: oklch(0.42 0.098 74);
+  color: var(--studio-warning);
 }
 
 .d-badge--danger {
-  border-color: oklch(0.55 0.15 28 / 0.22);
+  border-color: var(--studio-danger-border);
   background: var(--studio-danger-soft);
   color: var(--studio-danger);
 }
 
 .d-badge--info {
-  border-color: oklch(0.56 0.12 231 / 0.22);
+  border-color: var(--studio-info-border);
   background: var(--studio-info-soft);
   color: var(--studio-info);
 }

--- a/apps/studio/ui/src/design/atoms/Button.vue
+++ b/apps/studio/ui/src/design/atoms/Button.vue
@@ -76,7 +76,7 @@ withDefaults(
 
 .d-button--primary {
   background: var(--studio-accent);
-  color: oklch(0.99 0.004 246);
+  color: var(--studio-accent-contrast);
 }
 
 .d-button--primary:hover:not(:disabled) {
@@ -107,11 +107,11 @@ withDefaults(
 
 .d-button--danger {
   background: var(--studio-danger);
-  color: oklch(0.99 0.004 246);
+  color: var(--studio-danger-contrast);
 }
 
 .d-button--danger:hover:not(:disabled) {
-  background: oklch(48% 0.16 28);
+  background: var(--studio-danger-hover);
 }
 
 .d-button__spinner {

--- a/apps/studio/ui/src/design/atoms/Checkbox.vue
+++ b/apps/studio/ui/src/design/atoms/Checkbox.vue
@@ -59,7 +59,7 @@ defineEmits<{
   border: 1px solid var(--studio-border-strong);
   border-radius: 5px;
   background: var(--studio-control-bg);
-  color: oklch(0.99 0.004 246);
+  color: var(--studio-accent-contrast);
   box-shadow: var(--studio-shadow-control);
   line-height: 0;
   vertical-align: middle;

--- a/apps/studio/ui/src/design/atoms/IconButton.vue
+++ b/apps/studio/ui/src/design/atoms/IconButton.vue
@@ -91,7 +91,7 @@ withDefaults(defineProps<{
 }
 
 .d-icon-button--danger {
-  border-color: oklch(0.55 0.15 28 / 0.24);
+  border-color: var(--studio-danger-border);
   background: var(--studio-danger-soft);
   color: var(--studio-danger);
 }

--- a/apps/studio/ui/src/design/molecules/ErrorState.vue
+++ b/apps/studio/ui/src/design/molecules/ErrorState.vue
@@ -16,9 +16,9 @@ defineProps<{
 .d-error-state {
   display: grid;
   gap: 3px;
-  border: 1px solid oklch(0.55 0.15 28 / 0.24);
+  border: 1px solid color-mix(in oklch, var(--studio-danger) 24%, transparent);
   border-radius: 7px;
-  background: oklch(0.98 0.02 28);
+  background: var(--studio-danger-soft);
   color: var(--studio-danger);
   padding: 10px 12px;
 }

--- a/apps/studio/ui/src/design/organisms/DataTable.vue
+++ b/apps/studio/ui/src/design/organisms/DataTable.vue
@@ -484,7 +484,7 @@ function activateRow(row: DataTableRow, index: number, event: MouseEvent | Keybo
   overflow-x: hidden;
   overflow-y: auto;
   position: relative;
-  scrollbar-color: oklch(0.58 0.018 246 / 0.3) transparent;
+  scrollbar-color: var(--studio-scrollbar) transparent;
   scrollbar-width: thin;
 }
 
@@ -600,7 +600,7 @@ function activateRow(row: DataTableRow, index: number, event: MouseEvent | Keybo
 }
 
 .data-table__row--selected:hover td {
-  background: oklch(0.941 0.034 248);
+  background: var(--studio-accent-soft-strong);
 }
 
 .data-table__state {
@@ -626,13 +626,13 @@ function activateRow(row: DataTableRow, index: number, event: MouseEvent | Keybo
 
 .data-table__state[data-state='forbidden'] .data-table__state-icon,
 .data-table__state[data-state='unauthenticated'] .data-table__state-icon {
-  border-color: oklch(0.56 0.12 231 / 0.24);
+  border-color: var(--studio-info-border);
   background: var(--studio-info-soft);
   color: var(--studio-info);
 }
 
 .data-table__state[data-state='error'] .data-table__state-icon {
-  border-color: oklch(0.55 0.15 28 / 0.24);
+  border-color: var(--studio-danger-border);
   background: var(--studio-danger-soft);
   color: var(--studio-danger);
 }

--- a/apps/studio/ui/src/design/primitives/Switch.vue
+++ b/apps/studio/ui/src/design/primitives/Switch.vue
@@ -98,13 +98,14 @@ function updateValue(value: boolean) {
   width: 14px;
   height: 14px;
   border-radius: 999px;
-  background: var(--studio-surface);
-  box-shadow: 0 1px 2px oklch(0.225 0.018 246 / 0.2);
+  background: var(--studio-control-knob);
+  box-shadow: var(--studio-shadow-control);
   transform: translateX(0);
   transition: transform 160ms ease;
 }
 
 .d-switch[data-state='checked'] .d-switch__thumb {
+  background: var(--studio-accent-contrast);
   transform: translateX(14px);
 }
 </style>

--- a/apps/studio/ui/src/features/debug/DebugBar.vue
+++ b/apps/studio/ui/src/features/debug/DebugBar.vue
@@ -188,7 +188,7 @@ async function copyBundle() {
   </div>
 </template>
 
-<style scoped>
+<style>
 .studio-debug-indicator {
   position: fixed;
   left: 16px;
@@ -208,22 +208,18 @@ async function copyBundle() {
   height: 36px;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgb(255 255 255 / 0.08);
+  border: 1px solid var(--studio-border-strong);
   border-radius: 10px;
-  background: #0a0a0a;
-  box-shadow:
-    0 0 0 1px rgb(0 0 0 / 0.08),
-    0 8px 24px rgb(0 0 0 / 0.18);
-  color: #fafafa;
+  background: var(--studio-surface);
+  box-shadow: var(--studio-shadow);
+  color: var(--studio-text);
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 120ms ease;
 }
 
 .studio-debug-indicator__trigger:hover {
   transform: translateY(-1px);
-  box-shadow:
-    0 0 0 1px rgb(0 0 0 / 0.1),
-    0 12px 28px rgb(0 0 0 / 0.22);
+  box-shadow: var(--studio-shadow-sheet);
 }
 
 .studio-debug-indicator__trigger:focus-visible {
@@ -245,8 +241,8 @@ async function copyBundle() {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: oklch(0.55 0.15 28);
-  box-shadow: 0 0 0 1.5px #0a0a0a;
+  background: var(--studio-danger);
+  box-shadow: 0 0 0 1.5px var(--studio-surface);
 }
 
 /* Panel */
@@ -254,13 +250,11 @@ async function copyBundle() {
   width: min(320px, calc(100vw - 32px));
   max-height: calc(100dvh - 78px);
   overflow-y: auto;
-  border: 1px solid rgb(255 255 255 / 0.08);
+  border: 1px solid var(--studio-border-strong);
   border-radius: 12px;
-  background: #0a0a0a;
-  box-shadow:
-    0 0 0 1px rgb(0 0 0 / 0.2),
-    0 18px 40px rgb(0 0 0 / 0.28);
-  color: #fafafa;
+  background: var(--studio-surface);
+  box-shadow: var(--studio-shadow-sheet);
+  color: var(--studio-text);
 }
 
 .studio-debug-indicator__header {
@@ -268,7 +262,7 @@ async function copyBundle() {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  border-bottom: 1px solid rgb(255 255 255 / 0.08);
+  border-bottom: 1px solid var(--studio-border);
   padding: 10px 12px;
 }
 
@@ -287,18 +281,18 @@ async function copyBundle() {
   border: 0;
   border-radius: 5px;
   background: transparent;
-  color: #737373;
+  color: var(--studio-text-muted);
   cursor: pointer;
 }
 
 .studio-debug-indicator__icon-btn:hover {
-  background: rgb(255 255 255 / 0.08);
-  color: #fafafa;
+  background: var(--studio-surface-raised);
+  color: var(--studio-text);
 }
 
 /* Errors section */
 .studio-debug-indicator__errors {
-  border-bottom: 1px solid rgb(255 255 255 / 0.08);
+  border-bottom: 1px solid var(--studio-border);
 }
 
 .studio-debug-indicator__errors-header {
@@ -306,7 +300,7 @@ async function copyBundle() {
   align-items: center;
   gap: 6px;
   padding: 8px 12px 6px;
-  color: oklch(0.72 0.15 28);
+  color: var(--studio-danger);
   font-size: 11px;
   font-weight: 600;
 }
@@ -315,18 +309,18 @@ async function copyBundle() {
   margin-left: auto;
   border: 0;
   background: transparent;
-  color: #737373;
+  color: var(--studio-text-muted);
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
 }
 
 .studio-debug-indicator__clear:hover {
-  color: #fafafa;
+  color: var(--studio-text);
 }
 
 .studio-debug-indicator__error {
-  border-top: 1px solid rgb(255 255 255 / 0.05);
+  border-top: 1px solid var(--studio-border);
 }
 
 .studio-debug-indicator__error-toggle {
@@ -336,20 +330,20 @@ async function copyBundle() {
   gap: 6px;
   border: 0;
   background: transparent;
-  color: #fafafa;
+  color: var(--studio-text);
   padding: 7px 12px;
   text-align: left;
   cursor: pointer;
 }
 
 .studio-debug-indicator__error-toggle:hover {
-  background: rgb(255 255 255 / 0.04);
+  background: var(--studio-surface-raised);
 }
 
 .studio-debug-indicator__error-toggle svg {
   flex: 0 0 auto;
   margin-top: 1px;
-  color: #737373;
+  color: var(--studio-text-muted);
 }
 
 .studio-debug-indicator__error-msg {
@@ -364,9 +358,9 @@ async function copyBundle() {
 .studio-debug-indicator__stack {
   overflow-x: auto;
   margin: 0;
-  border-top: 1px solid rgb(255 255 255 / 0.05);
-  background: rgb(255 255 255 / 0.03);
-  color: #a1a1a1;
+  border-top: 1px solid var(--studio-border);
+  background: var(--studio-surface-raised);
+  color: var(--studio-text-muted);
   padding: 8px 12px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 10px;
@@ -392,7 +386,7 @@ async function copyBundle() {
 
 .studio-debug-indicator__row dt {
   margin: 0;
-  color: #737373;
+  color: var(--studio-text-muted);
   font-size: 11px;
   font-weight: 600;
   line-height: 1.35;
@@ -409,7 +403,7 @@ async function copyBundle() {
 
 .studio-debug-indicator__mono {
   overflow: hidden;
-  color: #fafafa;
+  color: var(--studio-text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
   font-weight: 550;
@@ -419,7 +413,7 @@ async function copyBundle() {
 
 .studio-debug-indicator__path {
   overflow: hidden;
-  color: #737373;
+  color: var(--studio-text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
   text-overflow: ellipsis;
@@ -430,7 +424,7 @@ async function copyBundle() {
 .studio-debug-indicator__footer {
   display: flex;
   gap: 6px;
-  border-top: 1px solid rgb(255 255 255 / 0.08);
+  border-top: 1px solid var(--studio-border);
   padding: 10px 12px;
 }
 
@@ -440,10 +434,10 @@ async function copyBundle() {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  border: 1px solid rgb(255 255 255 / 0.1);
+  border: 1px solid var(--studio-border-strong);
   border-radius: 7px;
-  background: rgb(255 255 255 / 0.06);
-  color: #fafafa;
+  background: var(--studio-control-bg);
+  color: var(--studio-text);
   padding: 0 10px;
   font-size: 11px;
   font-weight: 600;
@@ -451,19 +445,19 @@ async function copyBundle() {
 }
 
 .studio-debug-indicator__btn:hover {
-  background: rgb(255 255 255 / 0.1);
+  background: var(--studio-control-bg-hover);
 }
 
 .studio-debug-indicator__btn--muted {
   margin-left: auto;
   border-color: transparent;
   background: transparent;
-  color: #737373;
+  color: var(--studio-text-muted);
 }
 
 .studio-debug-indicator__btn--muted:hover {
-  background: rgb(255 255 255 / 0.06);
-  color: #fafafa;
+  background: var(--studio-surface-raised);
+  color: var(--studio-text);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/studio/ui/src/features/dialogs/DialogHost.vue
+++ b/apps/studio/ui/src/features/dialogs/DialogHost.vue
@@ -73,12 +73,12 @@ function buttonVariant(variant: StudioDialogActionVariant): 'primary' | 'seconda
   </DialogRoot>
 </template>
 
-<style scoped>
+<style>
 .studio-dialog__overlay {
   position: fixed;
   inset: 0;
   z-index: 80;
-  background: oklch(18% 0.02 246 / 0.34);
+  background: var(--studio-overlay);
 }
 
 .studio-dialog {

--- a/apps/studio/ui/src/features/notifications/NotificationMenu.vue
+++ b/apps/studio/ui/src/features/notifications/NotificationMenu.vue
@@ -80,7 +80,7 @@ async function selectNotification(id: number) {
   </DropdownMenuRoot>
 </template>
 
-<style scoped>
+<style>
 .studio-notifications__trigger {
   position: relative;
   display: inline-flex;
@@ -113,7 +113,7 @@ async function selectNotification(id: number) {
   border: 2px solid var(--studio-bg);
   border-radius: 999px;
   background: var(--studio-danger);
-  color: white;
+  color: var(--studio-danger-contrast);
   font-size: 9px;
   font-weight: 700;
   line-height: 12px;

--- a/apps/studio/ui/src/features/theme/index.ts
+++ b/apps/studio/ui/src/features/theme/index.ts
@@ -1,0 +1,14 @@
+export {
+  applyStudioTheme,
+  getStudioThemePreference,
+  installStudioTheme,
+  isStudioThemePreference,
+  readStudioThemePreference,
+  resolveStudioTheme,
+  setStudioThemePreference,
+  studioThemeOptions,
+  studioThemePreferences,
+  studioThemeStorageKey,
+  syncStudioTheme,
+} from './studio-theme.ts'
+export type { StudioResolvedTheme, StudioThemePreference } from './studio-theme.ts'

--- a/apps/studio/ui/src/features/theme/studio-theme.test.ts
+++ b/apps/studio/ui/src/features/theme/studio-theme.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  applyStudioTheme,
+  getStudioThemePreference,
+  installStudioTheme,
+  isStudioThemePreference,
+  readStudioThemePreference,
+  resolveStudioTheme,
+  setStudioThemePreference,
+  studioThemeOptions,
+  studioThemeStorageKey,
+  syncStudioTheme,
+} from './studio-theme.ts'
+
+test('readStudioThemePreference defaults to system and accepts stored values', () => {
+  assert.equal(readStudioThemePreference(null), 'system')
+  assert.equal(readStudioThemePreference('light'), 'light')
+  assert.equal(readStudioThemePreference('dark'), 'dark')
+  assert.equal(readStudioThemePreference('system'), 'system')
+  assert.equal(readStudioThemePreference('sepia'), 'system')
+})
+
+test('resolveStudioTheme follows explicit preference and system color scheme', () => {
+  assert.equal(resolveStudioTheme('light', true), 'light')
+  assert.equal(resolveStudioTheme('dark', false), 'dark')
+  assert.equal(resolveStudioTheme('system', true), 'dark')
+  assert.equal(resolveStudioTheme('system', false), 'light')
+})
+
+test('studio theme options cover light, dark, and system', () => {
+  assert.deepEqual(studioThemeOptions.map((option) => option?.value).filter(Boolean), ['light', 'dark', 'system'])
+})
+
+test('theme preferences remain safe when browser storage is unavailable', () => {
+  installWindow({
+    localStorage: {
+      getItem: () => {
+        throw new Error('storage unavailable')
+      },
+      setItem: () => {
+        throw new Error('storage unavailable')
+      },
+    },
+    matchMedia: () => ({
+      matches: true,
+      addEventListener: () => {
+        throw new Error('matchMedia unavailable')
+      },
+    }),
+  })
+
+  assert.equal(getStudioThemePreference(), 'system')
+  assert.doesNotThrow(() => setStudioThemePreference('dark'))
+  assert.doesNotThrow(() => installStudioTheme())
+})
+
+test('setStudioThemePreference persists and applies the resolved theme', () => {
+  const storage = memoryStorage()
+  const root = themeRoot()
+  installWindow({
+    localStorage: storage,
+    matchMedia: () => ({ matches: false, addEventListener() {} }),
+  })
+
+  assert.equal(setStudioThemePreference('dark', root), 'dark')
+  assert.equal(storage.getItem(studioThemeStorageKey), 'dark')
+  assert.equal(root.dataset.theme, 'dark')
+
+  storage.setItem(studioThemeStorageKey, 'system')
+  assert.equal(syncStudioTheme(root), 'light')
+  assert.equal(root.dataset.theme, 'light')
+})
+
+test('applyStudioTheme writes data-theme on the document root', () => {
+  const root = themeRoot()
+  applyStudioTheme('dark', root)
+  assert.equal(root.dataset.theme, 'dark')
+  applyStudioTheme('light', root)
+  assert.equal(root.dataset.theme, 'light')
+})
+
+test('Studio mounts after applying the stored theme', () => {
+  const source = readFileSync(new URL('../../app/main.ts', import.meta.url), 'utf8')
+  assert.match(source, /installStudioTheme\(\)/)
+})
+
+test('dark theme tokens override the light palette', () => {
+  const source = readFileSync(new URL('../../styles/base.css', import.meta.url), 'utf8')
+  assert.match(source, /:root\[data-theme='dark'\]/)
+  assert.match(source, /--studio-accent-contrast/)
+  assert.match(source, /--studio-overlay/)
+})
+
+test('debug bar inherits the active Studio theme across its portal', () => {
+  const source = readFileSync(new URL('../debug/DebugBar.vue', import.meta.url), 'utf8')
+  assert.match(source, /var\(--studio-surface\)/)
+  assert.match(source, /var\(--studio-text\)/)
+  assert.match(source, /<style>/)
+  assert.doesNotMatch(source, /<style scoped>/)
+  assert.doesNotMatch(source, /#[0-9a-f]{3,8}\b|(?:rgb|oklch)\(/i)
+})
+
+test('teleported Studio panels keep their component styles', () => {
+  for (const component of ['../dialogs/DialogHost.vue', '../notifications/NotificationMenu.vue']) {
+    const source = readFileSync(new URL(component, import.meta.url), 'utf8')
+    assert.match(source, /<style>/)
+    assert.doesNotMatch(source, /<style scoped>/)
+  }
+})
+
+test('index.html bootstraps the stored theme before Vue mounts', () => {
+  const source = readFileSync(new URL('../../../index.html', import.meta.url), 'utf8')
+  assert.match(source, /studio:theme/)
+  assert.match(source, /dataset\.theme/)
+  assert.match(source, /prefers-color-scheme: dark/)
+})
+
+test('UserMenu exposes a Theme submenu with light, dark, and system', () => {
+  const source = readFileSync(new URL('../../shell/UserMenu.vue', import.meta.url), 'utf8')
+  assert.match(source, /Theme/)
+  assert.match(source, /DropdownMenuRadioGroup/)
+  assert.match(source, /studioThemeOptions/)
+})
+
+test('isStudioThemePreference rejects unknown values', () => {
+  assert.equal(isStudioThemePreference('light'), true)
+  assert.equal(isStudioThemePreference('auto'), false)
+  assert.equal(isStudioThemePreference(1), false)
+})
+
+function installWindow(overrides: Record<string, unknown>) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: overrides,
+  })
+}
+
+function memoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value)
+    },
+  }
+}
+
+function themeRoot() {
+  return { dataset: {} as Record<string, string> } as unknown as HTMLElement
+}

--- a/apps/studio/ui/src/features/theme/studio-theme.ts
+++ b/apps/studio/ui/src/features/theme/studio-theme.ts
@@ -1,0 +1,108 @@
+export const studioThemeStorageKey = 'studio:theme'
+
+export const studioThemePreferences = ['light', 'dark', 'system'] as const
+
+export type StudioThemePreference = (typeof studioThemePreferences)[number]
+
+export type StudioResolvedTheme = 'light' | 'dark'
+
+export const studioThemeOptions: ReadonlyArray<{ value: StudioThemePreference; label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
+
+export function isStudioThemePreference(value: unknown): value is StudioThemePreference {
+  return value === 'light' || value === 'dark' || value === 'system'
+}
+
+export function readStudioThemePreference(storedValue: string | null): StudioThemePreference {
+  if (isStudioThemePreference(storedValue)) {
+    return storedValue
+  }
+
+  return 'system'
+}
+
+export function resolveStudioTheme(preference: StudioThemePreference, prefersDark: boolean): StudioResolvedTheme {
+  if (preference === 'light' || preference === 'dark') {
+    return preference
+  }
+
+  return prefersDark ? 'dark' : 'light'
+}
+
+export function prefersDarkColorScheme(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  } catch {
+    return false
+  }
+}
+
+export function getStudioThemePreference(): StudioThemePreference {
+  if (typeof window === 'undefined') {
+    return 'system'
+  }
+
+  try {
+    return readStudioThemePreference(window.localStorage.getItem(studioThemeStorageKey))
+  } catch {
+    return 'system'
+  }
+}
+
+export function applyStudioTheme(theme: StudioResolvedTheme, root?: HTMLElement | null): void {
+  const target = root ?? (typeof document === 'undefined' ? null : document.documentElement)
+  if (!target) {
+    return
+  }
+
+  target.dataset.theme = theme
+}
+
+export function syncStudioTheme(root?: HTMLElement | null): StudioResolvedTheme {
+  const theme = resolveStudioTheme(getStudioThemePreference(), prefersDarkColorScheme())
+  applyStudioTheme(theme, root)
+  return theme
+}
+
+export function setStudioThemePreference(preference: StudioThemePreference, root?: HTMLElement | null): StudioResolvedTheme {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(studioThemeStorageKey, preference)
+    } catch {
+      // Theme preferences are best-effort when browser storage is unavailable.
+    }
+  }
+
+  const theme = resolveStudioTheme(preference, prefersDarkColorScheme())
+  applyStudioTheme(theme, root)
+  return theme
+}
+
+let systemThemeBound = false
+
+export function installStudioTheme(): StudioResolvedTheme {
+  const theme = syncStudioTheme()
+  if (typeof window === 'undefined' || systemThemeBound) {
+    return theme
+  }
+
+  try {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if (getStudioThemePreference() === 'system') {
+        syncStudioTheme()
+      }
+    })
+    systemThemeBound = true
+  } catch {
+    // Color-scheme listeners are best-effort when matchMedia is unavailable.
+  }
+
+  return theme
+}

--- a/apps/studio/ui/src/shell/CommandMenu.vue
+++ b/apps/studio/ui/src/shell/CommandMenu.vue
@@ -602,7 +602,7 @@ function itemDomId(item: CommandItem): string {
   position: fixed;
   z-index: 60;
   inset: 0;
-  background: oklch(0.225 0.018 246 / 0.18);
+  background: var(--studio-overlay);
 }
 
 .studio-command-menu__dialog {

--- a/apps/studio/ui/src/shell/UserMenu.vue
+++ b/apps/studio/ui/src/shell/UserMenu.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { LogOut, RefreshCw } from '@lucide/vue'
+import { Check, ChevronRight, LogOut, Palette, RefreshCw } from '@lucide/vue'
 import {
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuItemIndicator,
   DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuRoot,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from 'reka-ui'
 import { useRouter } from 'vue-router'
@@ -14,6 +20,13 @@ import { useRouter } from 'vue-router'
 import { queryClient } from '@/app/query'
 import { reloadStudioApp } from '@/app/reload'
 import Avatar from '@/design/atoms/Avatar.vue'
+import {
+  getStudioThemePreference,
+  isStudioThemePreference,
+  setStudioThemePreference,
+  studioThemeOptions,
+  type StudioThemePreference,
+} from '@/features/theme'
 import { RouteName } from '@/router/routes'
 import { useAuthStore } from '@/stores/auth.store'
 
@@ -27,6 +40,7 @@ withDefaults(defineProps<{
 const router = useRouter()
 const authStore = useAuthStore()
 const reloading = ref(false)
+const themePreference = ref<StudioThemePreference>(getStudioThemePreference())
 
 async function reloadApp() {
   if (reloading.value) {
@@ -39,6 +53,15 @@ async function reloadApp() {
   } finally {
     reloading.value = false
   }
+}
+
+function onThemePreference(value: unknown) {
+  if (!isStudioThemePreference(value)) {
+    return
+  }
+
+  themePreference.value = value
+  setStudioThemePreference(value)
 }
 
 async function logout() {
@@ -66,6 +89,30 @@ async function logout() {
           <RefreshCw :size="14" :stroke-width="1.8" aria-hidden="true" />
           <span>Reload</span>
         </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger class="studio-user-menu__item">
+            <Palette :size="14" :stroke-width="1.8" aria-hidden="true" />
+            <span>Theme</span>
+            <ChevronRight class="studio-user-menu__chevron" :size="14" :stroke-width="1.8" aria-hidden="true" />
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent class="studio-user-menu__content" :side-offset="6">
+              <DropdownMenuRadioGroup :model-value="themePreference" @update:model-value="onThemePreference">
+                <DropdownMenuRadioItem
+                  v-for="option in studioThemeOptions"
+                  :key="option.value"
+                  class="studio-user-menu__item studio-user-menu__item--radio"
+                  :value="option.value"
+                >
+                  <DropdownMenuItemIndicator class="studio-user-menu__indicator">
+                    <Check :size="13" :stroke-width="2.2" aria-hidden="true" />
+                  </DropdownMenuItemIndicator>
+                  <span>{{ option.label }}</span>
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
         <DropdownMenuSeparator class="studio-user-menu__separator" />
         <DropdownMenuItem class="studio-user-menu__item" @select="logout">
           <LogOut :size="14" :stroke-width="1.8" aria-hidden="true" />
@@ -119,7 +166,13 @@ async function logout() {
   user-select: none;
 }
 
-.studio-user-menu__item[data-highlighted] {
+.studio-user-menu__item--radio {
+  position: relative;
+  padding-left: 28px;
+}
+
+.studio-user-menu__item[data-highlighted],
+.studio-user-menu__item[data-state='open'] {
   background: var(--studio-surface-raised);
   color: var(--studio-text);
 }
@@ -127,6 +180,19 @@ async function logout() {
 .studio-user-menu__item[data-disabled] {
   color: var(--studio-text-subtle);
   pointer-events: none;
+}
+
+.studio-user-menu__chevron {
+  margin-left: auto;
+}
+
+.studio-user-menu__indicator {
+  position: absolute;
+  left: 8px;
+  display: inline-flex;
+  width: 14px;
+  align-items: center;
+  justify-content: center;
 }
 
 .studio-user-menu__separator {

--- a/apps/studio/ui/src/styles/base.css
+++ b/apps/studio/ui/src/styles/base.css
@@ -20,21 +20,34 @@
   --studio-text-subtle: #8d9098;
   --studio-accent: #252525;
   --studio-accent-strong: #252525;
+  --studio-accent-contrast: #ffffff;
   --studio-focus: #252525;
   --studio-danger: oklch(0.55 0.15 28);
+  --studio-danger-hover: oklch(0.48 0.16 28);
+  --studio-danger-contrast: #ffffff;
   --studio-warning: oklch(0.63 0.13 74);
   --studio-success: oklch(0.52 0.105 156);
   --studio-info: #252525;
+  --studio-accent-border: oklch(0.49 0.118 248 / 0.22);
+  --studio-danger-border: oklch(0.55 0.15 28 / 0.24);
+  --studio-warning-border: oklch(0.63 0.13 74 / 0.26);
+  --studio-success-border: oklch(0.52 0.105 156 / 0.22);
+  --studio-info-border: oklch(0.49 0.118 248 / 0.22);
   --studio-danger-soft: oklch(0.975 0.014 28);
   --studio-warning-soft: oklch(0.976 0.026 74);
   --studio-success-soft: oklch(0.967 0.022 156);
   --studio-info-soft: #f7f7f7;
   --studio-accent-soft: #f5f5f5;
+  --studio-accent-soft-strong: #ececec;
   --studio-neutral-soft: #f2f2f2;
+  --studio-scrollbar: rgb(37 37 37 / 0.32);
+  --studio-scrollbar-hover: rgb(37 37 37 / 0.44);
   --studio-control-bg: var(--studio-surface);
   --studio-control-bg-hover: #f8f8f8;
   --studio-control-bg-disabled: #efefef;
   --studio-control-bg-readonly: #f5f5f5;
+  --studio-control-knob: #ffffff;
+  --studio-overlay: rgb(37 37 37 / 0.28);
   --studio-control-height-xs: 30px;
   --studio-control-height-sm: 32px;
   --studio-control-height-md: 38px;
@@ -57,9 +70,60 @@
     0 0 24px rgb(37 37 37 / 0.045);
 }
 
+:root[data-theme='dark'] {
+  color-scheme: dark;
+
+  --studio-bg: #141414;
+  --studio-surface: #1c1c1c;
+  --studio-surface-raised: #242424;
+  --studio-sidebar: #141414;
+  --studio-border: #2e2e2e;
+  --studio-border-strong: #3a3a3a;
+  --studio-text: #f2f2f2;
+  --studio-text-muted: #a3a6ad;
+  --studio-text-subtle: #7a7d84;
+  --studio-accent: #f2f2f2;
+  --studio-accent-strong: #ffffff;
+  --studio-accent-contrast: #141414;
+  --studio-focus: #f2f2f2;
+  --studio-danger: oklch(0.72 0.14 28);
+  --studio-danger-hover: oklch(0.66 0.15 28);
+  --studio-danger-contrast: #141414;
+  --studio-warning: oklch(0.78 0.12 74);
+  --studio-success: oklch(0.72 0.1 156);
+  --studio-info: #f2f2f2;
+  --studio-accent-border: rgb(242 242 242 / 0.2);
+  --studio-danger-border: oklch(0.72 0.14 28 / 0.3);
+  --studio-warning-border: oklch(0.78 0.12 74 / 0.3);
+  --studio-success-border: oklch(0.72 0.1 156 / 0.28);
+  --studio-info-border: rgb(242 242 242 / 0.2);
+  --studio-danger-soft: oklch(0.28 0.04 28);
+  --studio-warning-soft: oklch(0.3 0.04 74);
+  --studio-success-soft: oklch(0.28 0.035 156);
+  --studio-info-soft: #242424;
+  --studio-accent-soft: #2a2a2a;
+  --studio-accent-soft-strong: #333333;
+  --studio-neutral-soft: #2a2a2a;
+  --studio-control-bg: var(--studio-surface);
+  --studio-control-bg-hover: #262626;
+  --studio-control-bg-disabled: #1a1a1a;
+  --studio-control-bg-readonly: #1a1a1a;
+  --studio-control-knob: #f2f2f2;
+  --studio-overlay: rgb(0 0 0 / 0.56);
+  --studio-focus-ring: 0 0 0 3px rgb(242 242 242 / 0.24);
+  --studio-danger-ring: 0 0 0 3px oklch(0.72 0.14 28 / 0.22);
+  --studio-shadow: 0 1px 2px rgb(0 0 0 / 0.4),
+    0 18px 46px rgb(0 0 0 / 0.35);
+  --studio-shadow-control: 0 1px 1px rgb(0 0 0 / 0.25);
+  --studio-shadow-sheet: 0 0 1px rgb(0 0 0 / 0.4),
+    0 0 24px rgb(0 0 0 / 0.35);
+  --studio-scrollbar: rgb(242 242 242 / 0.28);
+  --studio-scrollbar-hover: rgb(242 242 242 / 0.42);
+}
+
 * {
   box-sizing: border-box;
-  scrollbar-color: rgb(37 37 37 / 0.35) transparent;
+  scrollbar-color: var(--studio-scrollbar) transparent;
   scrollbar-width: thin;
 }
 
@@ -74,11 +138,11 @@
 
 *::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: rgb(37 37 37 / 0.32);
+  background: var(--studio-scrollbar);
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background: rgb(37 37 37 / 0.44);
+  background: var(--studio-scrollbar-hover);
 }
 
 html {
@@ -164,6 +228,29 @@ body > [data-reka-popper-content-wrapper] {
 
 .studio-user-menu__item {
   min-height: 30px;
+}
+
+.studio-user-menu__item--radio {
+  position: relative;
+  padding-left: 28px;
+}
+
+.studio-user-menu__item[data-state='open'] {
+  background: var(--studio-surface-raised);
+  color: var(--studio-text);
+}
+
+.studio-user-menu__chevron {
+  margin-left: auto;
+}
+
+.studio-user-menu__indicator {
+  position: absolute;
+  left: 8px;
+  display: inline-flex;
+  width: 14px;
+  align-items: center;
+  justify-content: center;
 }
 
 .d-dropdown-menu__item[data-highlighted],

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -78,3 +78,13 @@ The default path is:
 3. Let Studio render the app globally.
 
 Custom UI is coming soon, but the basic app shape should work through Studio metadata first.
+
+## Appearance
+
+Studio uses Light, Dark, or System appearance.
+
+Open the user menu in the header and choose Theme.
+
+Light and Dark stay fixed. System follows the operating system color scheme.
+
+Studio stores the preference in the browser. The choice applies across Records, lists, forms, login, and the rest of the Studio shell.


### PR DESCRIPTION

## Summary

  Closes hapyco/dygo#194.

  Adds complete Studio theming support with Light, Dark, and System modes.

  ## Changes

  - Added persistent Light, Dark, and System theme preferences
  - Applied the theme before initial rendering to prevent flashing
  - Added theme controls to the user menu
  - Added a comprehensive dark-mode token palette
  - Updated buttons, inputs, dropdowns, dialogs, tables, badges, switches, checkboxes, and error states
  - Fixed opaque, theme-aware backgrounds for notification and other teleported dropdowns
  - Restored and themed the Studio debug bar
  - Added automated tests for theme behavior
  - Documented Studio theme preferences

  ## Verification

  - `npm test` — 70/70 tests passing
  - `npm run build` — passing
  - `git diff --check` — passing
  - Manually verified Light and Dark modes
  - Verified persisted theme selection and System preference behavior
  - Verified dropdowns, notifications, dialogs, inputs, buttons, tables, and the debug bar in both themes

  ## Notes

  Encrypted environment secret changes are intentionally excluded from this PR.
 