### PR TITLE
feat: add encrypted secret fields

### DIFF
--- a/apps/studio/ui/src/features/records/record-form.query.ts
+++ b/apps/studio/ui/src/features/records/record-form.query.ts
@@ -5,6 +5,7 @@ import { queryClient } from '@/app/query'
 import { studioSounds } from '@/features/sounds'
 import { recordListBaseQueryKey } from './record-list.query'
 import {
+  getSecretStatus,
   createRecord,
   addRecordComment,
   deleteRecord,
@@ -191,5 +192,14 @@ function cacheNamedRecord(entity: string, record: RecordData) {
 }
 
 function invalidateRecordLists(entity: string) {
+  void queryClient.invalidateQueries({ queryKey: ['records', 'secret-status', entity] })
   void queryClient.invalidateQueries({ queryKey: recordListBaseQueryKey(entity) })
+}
+
+export function useSecretStatusQuery(entity: MaybeRefOrGetter<string>, id: MaybeRefOrGetter<number>, enabled: QueryToggle) {
+  return useQuery({
+    queryKey: computed(() => ['records', 'secret-status', toValue(entity), toValue(id)]),
+    queryFn: ({ signal }) => getSecretStatus(toValue(entity), toValue(id), signal),
+    enabled: computed(() => toValue(enabled) && toValue(id) > 0),
+  })
 }

--- a/apps/studio/ui/src/features/records/records.api.ts
+++ b/apps/studio/ui/src/features/records/records.api.ts
@@ -220,3 +220,9 @@ function recordErrorMessage(payload: ApiErrorEnvelope): string {
       return payload.error?.message ?? 'Studio could not load records.'
   }
 }
+
+export type SecretStatus = { fields: Record<string, boolean>, collections?: Record<string, Record<string, Record<string, boolean>>> }
+export async function getSecretStatus(entity: string, id: number, signal?: AbortSignal): Promise<SecretStatus> {
+  const response = await apiRequest<DataEnvelope<SecretStatus>, RecordApiError>(`/api/v1/records/${encodeURIComponent(entity)}/${id}/secret-status`, { method: 'GET', signal }, recordRequestOptions('secret_status_failed'))
+  return response.data
+}

--- a/apps/studio/ui/src/features/records/secret-input.test.ts
+++ b/apps/studio/ui/src/features/records/secret-input.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { secretSubmitValue } from './secret-input.ts'
+
+test('secret input preserves existing values and clears only explicitly', () => {
+  for (const value of [undefined, '']) assert.deepEqual(secretSubmitValue(value, true, true), { skip: true })
+  assert.deepEqual(secretSubmitValue(null, false, true), { value: null })
+  assert.deepEqual(secretSubmitValue(' replacement ', true, true), { value: ' replacement ' })
+  assert.ok(secretSubmitValue(undefined, true, false).error)
+  assert.ok(secretSubmitValue(null, true, true).error)
+})

--- a/apps/studio/ui/src/features/records/secret-input.ts
+++ b/apps/studio/ui/src/features/records/secret-input.ts
@@ -1,0 +1,7 @@
+// An empty editor preserves the saved value. Only the Clear control emits null.
+export function secretSubmitValue(value: unknown, required: boolean, existing: boolean): { skip?: boolean, value?: unknown, error?: string } {
+  if (value === null && !required) return { value: null }
+  if (typeof value === 'string' && value !== '') return { value }
+  if (required && (!existing || value === null)) return { skip: true, error: 'Enter a secret.' }
+  return { skip: true }
+}

--- a/apps/studio/ui/src/pages/RecordFormPage.vue
+++ b/apps/studio/ui/src/pages/RecordFormPage.vue
@@ -9,6 +9,7 @@ import { useToast } from '@/features/toasts/use-toast'
 import type { MetadataEntityMeta, MetadataField } from '@/features/metadata/metadata.api'
 import { useMetadataEntityMetaQuery } from '@/features/metadata/metadata.query'
 import {
+  useSecretStatusQuery,
   useCreateRecordMutation,
   useAddRecordCommentMutation,
   useDeleteRecordMutation,
@@ -19,6 +20,7 @@ import {
   useRecordActivityQuery,
 } from '@/features/records/record-form.query'
 import type { RecordData } from '@/features/records/records.api'
+import { secretSubmitValue } from '@/features/records/secret-input'
 import { isHiddenRecordSubmitField, recordFieldLabel } from '@/features/records/system-fields'
 import { RecordFormRenderer, RecordTimeline } from '@/renderers/records'
 import { RouteName } from '@/router/routes'
@@ -113,6 +115,10 @@ const timelineQuery = useRecordActivityQuery(
   timelineRecordID,
   { enabled: computed(() => Number(timelineRecordID.value) > 0) },
 )
+const secretStatusQuery = useSecretStatusQuery(() => props.entity, () => Number(record.value?.id) || 0, computed(() => Boolean(
+  entityMeta.value?.fields.some(field => field.type === 'secret') || Object.values(entityMeta.value?.collections ?? {}).some(child => child.fields.some(field => field.type === 'secret'))
+)))
+const secretStatus = computed(() => secretStatusQuery.data.value)
 const commentDraft = ref('')
 const timelineError = computed(() => timelineQuery.error.value?.message || addCommentMutation.error.value?.message || '')
 const timelineEntries = computed(() => timelineQuery.data.value?.data ?? [])
@@ -444,6 +450,11 @@ function convertSubmitValue(field: MetadataField, value: unknown, errors: Record
   }
 
   switch (field['value-kind']) {
+    case 'secret': {
+      const result = secretSubmitValue(value, field.required, !isNew.value)
+      if (result.error) errors[field.name] = result.error
+      return result
+    }
     case 'password':
       if (typeof value !== 'string' || value.length === 0) {
         return { skip: true }
@@ -535,6 +546,11 @@ function collectionRowSubmitValue(parentField: MetadataField, childMeta: Metadat
 }
 
 function collectionCellSubmitValue(parentField: MetadataField, field: MetadataField, value: unknown, rowIndex: number, existing: boolean, errors: Record<string, string>): ConvertedValue {
+  if (field.type === 'secret') {
+    const result = secretSubmitValue(value, field.required, existing)
+    if (result.error) setCollectionError(errors, parentField, rowIndex, `${recordFieldLabel(field)} is required.`)
+    return result
+  }
   if (isBlankValue(value)) {
     if (field.required) {
       setCollectionError(errors, parentField, rowIndex, `${recordFieldLabel(field)} is required.`)
@@ -804,6 +820,7 @@ function draftValuesEqual(left: unknown, right: unknown): boolean {
           :message="saveError"
         />
 
+        <ErrorState v-if="secretStatusQuery.isError.value" title="Secret status unavailable" message="Reload the page to try again." />
         <RecordFormRenderer
       :entity="props.entity"
       :app-name="entityMeta?.app.name ?? ''"
@@ -813,6 +830,7 @@ function draftValuesEqual(left: unknown, right: unknown): boolean {
           :system-fields="systemFields"
           :collections="entityMeta.collections"
           :record="record"
+          :secret-status="secretStatus"
           :mode="props.mode"
           :model-value="draft"
           :field-errors="fieldErrors"

--- a/apps/studio/ui/src/renderers/records/RecordCollectionTable.vue
+++ b/apps/studio/ui/src/renderers/records/RecordCollectionTable.vue
@@ -6,12 +6,14 @@ import { Button, IconButton, Input, Select, Switch, Textarea, type FieldOption, 
 import type { MetadataEntityMeta, MetadataField } from '@/features/metadata/metadata.api'
 import type { RecordData } from '@/features/records/records.api'
 import { recordFieldLabel } from '@/features/records/system-fields'
+import SecretEditor from './SecretEditor.vue'
 import LinkPicker from './LinkPicker.vue'
 
 const props = withDefaults(defineProps<{
   id: string
   label: string
   field: MetadataField
+  secretStatus?: Record<string, Record<string, boolean>>
   childMeta?: MetadataEntityMeta
   modelValue?: unknown
   error?: string
@@ -272,6 +274,16 @@ function isHiddenCollectionField(field: MetadataField): boolean {
                 @update:model-value="updateCell(rowIndex, column, $event)"
               />
 
+              <SecretEditor
+                v-else-if="column.type === 'secret'"
+                :id="fieldId(column, rowIndex)"
+                :label="recordFieldLabel(column)"
+                :model-value="row[column.name]"
+                :present="row.id ? secretStatus?.[String(row.id)]?.[column.name] : false"
+                :required="column.required"
+                :disabled="disabled"
+                @update:model-value="updateCell(rowIndex, column, $event)"
+              />
               <Input
                 v-else-if="isTextField(column)"
                 :id="fieldId(column, rowIndex)"

--- a/apps/studio/ui/src/renderers/records/RecordFormRenderer.vue
+++ b/apps/studio/ui/src/renderers/records/RecordFormRenderer.vue
@@ -15,6 +15,8 @@ import { linkOptions, type MetadataEntityMeta, type MetadataField } from '@/feat
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
 import { uploadRecordFile, type RecordData } from '@/features/records/records.api'
 import { isHiddenRecordFormField, recordFieldLabel } from '@/features/records/system-fields'
+import SecretEditor from './SecretEditor.vue'
+import type { SecretStatus } from '@/features/records/records.api'
 import RecordCollectionTable from './RecordCollectionTable.vue'
 import LinkPicker from './LinkPicker.vue'
 import AttachmentEditor from './AttachmentEditor.vue'
@@ -28,6 +30,7 @@ const props = withDefaults(defineProps<{
   fields: MetadataField[]
   systemFields?: MetadataField[]
   collections?: Record<string, MetadataEntityMeta>
+  secretStatus?: SecretStatus
   record?: RecordData | null
   mode: 'new' | 'record' | 'single'
   modelValue: RecordData
@@ -167,6 +170,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         :label="recordFieldLabel(field)"
         :field="field"
         :child-meta="collections?.[field.name]"
+        :secret-status="secretStatus?.collections?.[field.name]"
         :model-value="modelValue[field.name]"
         :required="field.required"
         :disabled="disabled"
@@ -174,6 +178,18 @@ function selectOptions(field: MetadataField): FieldOption[] {
         @update:model-value="updateField(field, $event)"
         @open-related="openRelated($event.field, $event.recordName)"
         @create-related="createRelated($event)"
+      />
+
+      <SecretEditor
+        v-else-if="field.type === 'secret'"
+        :id="fieldId(field)"
+        :label="recordFieldLabel(field)"
+        :model-value="modelValue[field.name]"
+        :present="mode === 'new' ? false : secretStatus?.fields[field.name]"
+        :required="field.required"
+        :disabled="disabled"
+        :error="fieldErrors[field.name]"
+        @update:model-value="updateField(field, $event)"
       />
 
       <PasswordField

--- a/apps/studio/ui/src/renderers/records/SecretEditor.vue
+++ b/apps/studio/ui/src/renderers/records/SecretEditor.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { Button, PasswordField } from '@/design'
+
+defineProps<{
+  id: string
+  label: string
+  modelValue?: unknown
+  present?: boolean
+  required?: boolean
+  disabled?: boolean
+  error?: string
+}>()
+const emit = defineEmits<{ 'update:modelValue': [value: string | null | undefined] }>()
+</script>
+
+<template>
+  <div class="grid gap-1">
+    <PasswordField
+      :id="id"
+      :label="label"
+      :model-value="typeof modelValue === 'string' ? modelValue : ''"
+      :hint="modelValue === null ? 'Will be cleared' : present === undefined ? 'Status unavailable' : present ? 'Set' : 'Not set'"
+      :disabled="disabled"
+      :error="error"
+      autocomplete="new-password"
+      @update:model-value="emit('update:modelValue', $event === '' ? undefined : $event)"
+    />
+    <Button v-if="!required" type="button" variant="ghost" size="xs" :disabled="disabled" @click="emit('update:modelValue', null)">Clear</Button>
+  </div>
+</template>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -221,3 +221,11 @@ dygo upgrade
 - Destructive commands can run in `development`.
 - Protected environments such as `staging` and `production` block destructive commands unless `--force` is passed.
 - Read-only commands such as `--dry-run`, `check`, and validation commands never need `--force`.
+
+## Record encryption keys
+
+- `dygo secret record-key init --env <environment> --yes`: initialize the Record key in encrypted credentials without replacing an existing key.
+- `dygo secret record-key rotate --env <environment> --offline --yes`: re-encrypt Record secrets while servers and workers are stopped.
+- Add `--dry-run` to show the selected target without changes.
+
+See [Record encryption keys](secrets.md#record-encryption-keys) for backup and recovery steps.

--- a/docs/entity-metadata.md
+++ b/docs/entity-metadata.md
@@ -151,7 +151,7 @@ Collection Entities are non-routeable, hidden from normal Studio navigation, and
 
 Collection row Entities do not define top-level `name:` metadata. dygo assigns framework-owned random row names with length `16`, and inline collection editors do not expose `name` as an editable field.
 
-Current metadata-driven schema sync supports scalar fields, `select`, `link`, `password`, and collection row storage. Parent collection fields are virtual and do not create a parent table column. The child collection table stores `id`, `name`, `created_at`, `updated_at`, `parent_entity_id`, `parent_record_id`, `parent_field_id`, `ordinal`, and the child Entity's own stored field columns. `parent_entity_id` is an FK to Core `entity`, `parent_field_id` is an FK to Core `field`, and `parent_record_id` is a bigint because the parent table depends on `parent_entity_id`. dygo deletes child rows transactionally when deleting the parent Record. `(parent_entity_id, parent_record_id, parent_field_id, ordinal)` is unique with a deferrable initially deferred constraint, and `(parent_entity_id, parent_record_id, parent_field_id)` is indexed for ordered child row reads.
+Current metadata-driven schema sync supports scalar fields, `select`, `link`, `password`, `secret`, and collection row storage. Parent collection fields are virtual and do not create a parent table column. The child collection table stores `id`, `name`, `created_at`, `updated_at`, `parent_entity_id`, `parent_record_id`, `parent_field_id`, `ordinal`, and the child Entity's own stored field columns. `parent_entity_id` is an FK to Core `entity`, `parent_field_id` is an FK to Core `field`, and `parent_record_id` is a bigint because the parent table depends on `parent_entity_id`. dygo deletes child rows transactionally when deleting the parent Record. `(parent_entity_id, parent_record_id, parent_field_id, ordinal)` is unique with a deferrable initially deferred constraint, and `(parent_entity_id, parent_record_id, parent_field_id)` is indexed for ordered child row reads.
 
 Field `name`, `label`, and `type` are required.
 
@@ -283,7 +283,7 @@ Index and constraint names are optional. If omitted, dygo derives deterministic 
 
 Supported field check operators are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, and `not-in`. Field checks must use structured metadata, not raw SQL.
 
-Check fields must be DB-backed scalar fields. `password`, `collection`, `json`, `attachment`, and `link` checks are not supported in v1.
+Check fields must be DB-backed scalar fields. `password`, `secret`, `collection`, `json`, `attachment`, and `link` checks are not supported in v1.
 
 During `dygo db migrate`, normal Entity name metadata is upserted into the Core `entity` table. Collection row Entities omit naming metadata because their row names are framework-owned. Field metadata is upserted into the Core `field` table with field-name, label, type, required, unique, index, default, check, fetch, position, and options. Top-level Entity `indexes` and `constraints` are upserted into the Core `index` and `constraint` tables.
 
@@ -336,6 +336,7 @@ text
 email
 phone
 password
+secret
 long-text
 int
 bigint
@@ -355,6 +356,11 @@ json
 Field types are registered in Go. App-defined field types in YAML are out of scope for v1.
 
 `password` fields are write-only Record fields. Metadata uses the clean field name, such as `password`, while storage uses a hash column, such as `password_hash`. Password fields cannot be indexed, unique, defaulted, or used in top-level indexes or constraints.
+
+`secret` fields store decryptable ciphertext, not password hashes. Use them for
+integration credentials. Storage uses `<field>_encrypted`; values are omitted
+from ordinary reads. Required values are enforced by Record validation. See
+[Secret fields](records.md#secret-fields) and [Record encryption keys](secrets.md#record-encryption-keys).
 
 ## App Discovery
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -209,3 +209,41 @@ Administrator users are privileged through the permission engine.
 The permission engine applies row conditions, owner rules, and field read/write restrictions to Record access. Collection fields use the parent Record's field restrictions. See [Access](access.md) for policy metadata.
 
 Sharing, saved views, and richer Studio list UI remain separate follow-up work.
+
+## Secret fields
+
+A `secret` field accepts a non-empty string and stores age ciphertext in a
+nullable `<field>_encrypted` text column. Field names use the normal kebab-case
+to snake_case storage conversion. Encryption is randomized and bound to the
+App, Entity, and field identity. It is separate from password hashing.
+
+Omit a secret field to keep its value. Send `null` to clear an optional field.
+Empty strings and clearing required fields are rejected. Required fields must
+be supplied when creating a Record. Adding a required secret to existing Records
+does not populate them; provision their values explicitly. No existing text or
+password values are converted automatically.
+
+Generic Record reads, mutation responses, exports, and Activity snapshots omit
+both plaintext and ciphertext. Secret fields cannot have defaults, indexes,
+uniqueness, checks, fetch rules, filters, sorts, grouping, aggregates, or naming
+roles. Fixtures cannot supply secret values.
+
+`GET /api/v1/records/{entity}/{id}/secret-status` returns presence only:
+
+```json
+{"data":{"fields":{"token":true},"collections":{"connections":{"42":{"token":false}}}}}
+```
+
+This endpoint requires normal Record read permission and applies row and field
+read rules. Collection status uses the parent's collection-field permission.
+Use the saved Record ID for Single Entities. There is no HTTP reveal endpoint.
+
+Studio shows presence, a masked replacement input, and a Clear control for
+optional fields. An untouched or emptied input does not replace the saved value.
+A failed status request displays an error rather than reporting an unset value.
+
+Hooks do not receive submitted secrets, including secrets in collection rows.
+They may edit other submitted values. They cannot inject secret fields into Hook
+input. Collection rows containing secret metadata retain their submitted row
+structure and order during Hooks; use explicit Record operations for structural
+changes. After-write Hooks can use the system SDK to decrypt persisted values.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -190,9 +190,10 @@ same SDK operation. Collection decryption uses the child Entity and saved row ID
 
 Decryption uses the current transaction. It records the target, field, reason,
 actor context, and outcome through the framework Log writer. Audit write failure
-prevents returning plaintext. A contextual Log writer can persist outside the
-Record transaction, as it does in Hooks; without one, audit writes use the SDK's
-current transaction and roll back with it.
+prevents returning plaintext. The public contextual Log writer cannot replace
+this security sink. Audit writes use the SDK's current queryer, so Hook
+decryption uses the active Record transaction and does not require another pool
+checkout.
 
 The returned string is plaintext. Do not log it, add it to Job payloads, return it
 through an Action response, or include it in errors. Use it only for the intended

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -172,3 +172,32 @@ dygo.Config        - app/runtime config reads
 dygo.Secrets       - controlled secret reads
 dygo.Metadata      - Entity, Field, and Page metadata reads
 ```
+
+## Read a Record secret
+
+Use `RecordData.DecryptSecret` only in explicit system code:
+
+```go
+value, err := hook.Records.AsSystem("send integration request").DecryptSecret(
+    ctx, "crm", "connection", hook.RecordID, "token",
+)
+```
+
+Ordinary SDK access and `AsActor`, including Administrator access, cannot decrypt
+secrets. `AsSystem` requires a non-empty reason. Core and Business Apps use this
+same SDK operation. Collection decryption uses the child Entity and saved row ID.
+`errors.Is(err, dygo.ErrSecretUnset)` identifies an unset secret.
+
+Decryption uses the current transaction. It records the target, field, reason,
+actor context, and outcome through the framework Log writer. Audit write failure
+prevents returning plaintext. A contextual Log writer can persist outside the
+Record transaction, as it does in Hooks; without one, audit writes use the SDK's
+current transaction and roll back with it.
+
+The returned string is plaintext. Do not log it, add it to Job payloads, return it
+through an Action response, or include it in errors. Use it only for the intended
+server-side operation.
+
+`RecordData.SecretStatus(ctx, app, entity, recordID)` returns `dygo.SecretStatus`
+with presence maps, applying the SDK's normal read scope. Generic reads remain
+write-only even in system mode.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -184,3 +184,60 @@ Secrets can only be changed through `dygo secret edit` and read through `dygo se
 `.dygo/secrets/master.key` is intentionally project-local for now. Sharing it, backing it up, and injecting it into deployment environments are operational concerns outside this first implementation.
 
 dygo still uses one local root key for development, staging, and production. Per-environment recipients, KMS, Vault, and other external production secret providers are coming soon.
+
+## Record encryption keys
+
+The `secret` Entity field uses the existing credential store. Its dedicated
+Record keys are a structured `_record_encryption` mapping inside
+`config/secrets/<environment>.yml.age`. The existing master key protects this
+file. No separate plaintext Record key file is created. Do not edit this mapping
+by hand or copy its contents into source code.
+
+Initialize the existing credential store with `dygo secret init` if necessary.
+Then initialize the Record key for the selected environment:
+
+```sh
+dygo secret record-key init --env development --dry-run
+dygo secret record-key init --env development --yes
+```
+
+Initialization preserves existing keys. Invalid key configuration produces an
+error; initialization does not replace it. Projects without `secret` fields do
+not need Record keys. The CLI supplies the selected environment's key provider
+to server, worker, and other runtime command contexts. Missing keys prevent
+secret encryption and decryption. Ordinary reads do not decrypt secrets.
+
+### Rotate a Record key
+
+1. Stop all servers, workers, and other database writers for the environment.
+2. Back up the database, encrypted environment YAML, and existing master key.
+   Keep the master key in secure storage separate from the database backup.
+3. Review the target, then run the rotation command:
+
+```sh
+dygo secret record-key rotate --env production --offline --dry-run
+dygo secret record-key rotate --env production --offline --yes
+```
+
+4. Wait for `Record key rotate complete`. Restart servers and workers.
+
+`--offline` confirms that you stopped the writers; it does not stop them for you.
+An advisory lock prevents two Record key commands from running together.
+Rotation saves the new key in encrypted YAML before it rewrites any Record.
+It commits batches of 100 values and verifies all live metadata-defined secret
+columns, including Single Entities and collection rows. It does not run
+business Hooks or change Record timestamps.
+
+If rotation stops, keep writers stopped and run the same command again. The
+saved rotation state reuses the new key and skips values already encrypted with
+it. A missing old key or corrupt ciphertext stops rotation. Restore the affected
+key or value from a backup before retrying; do not replace the entire key ring.
+
+Old identities remain in encrypted YAML after rotation so older database backups
+remain readable. Automatic key deletion is not supported. Back up the updated
+encrypted YAML after rotation.
+
+`dygo secret rotate-key` changes the credential store's master key and re-encrypts
+the environment YAML files. `dygo secret record-key rotate` changes the Record
+data key and re-encrypts database values. These are separate operations. Do not
+run credential edits or master-key rotation during Record-key rotation.

--- a/internal/cli/record_key.go
+++ b/internal/cli/record_key.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/internal/recordsecret"
+	"github.com/hapyco/dygo/internal/secrets"
+	"github.com/jackc/pgx/v5"
+	"github.com/spf13/cobra"
+)
+
+func newRecordKeyCommand(ctx context.Context, stdout io.Writer) *cobra.Command {
+	parent := &cobra.Command{Use: "record-key", Short: "Manage Record encryption keys", Args: cobra.NoArgs}
+	for _, operation := range []string{"init", "rotate"} {
+		envName := "development"
+		yes := false
+		offline := false
+		dryRun := false
+		cmd := &cobra.Command{Use: operation, Short: operation + " Record encryption key", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error {
+			if operation == "rotate" && !offline {
+				return errors.New("stop servers and workers, then pass --offline to confirm")
+			}
+			env, root, url, err := databaseInputs(envName)
+			if err != nil {
+				return err
+			}
+			if _, err = fmt.Fprintf(stdout, "Record key %s (%s)\nproject: %s\n", operation, env, root); err != nil {
+				return err
+			}
+			if dryRun {
+				return nil
+			}
+			if !yes {
+				return errors.New("review the target, then pass --yes")
+			}
+			conn, err := pgx.Connect(ctx, url)
+			if err != nil {
+				return db.SanitizeDatabaseError("connect Record key database", url, err)
+			}
+			defer conn.Close(context.Background())
+			var locked bool
+			if err = conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", db.RecordKeyLock).Scan(&locked); err != nil {
+				return errors.New("acquire Record key lock failed")
+			}
+			if !locked {
+				return errors.New("another Record key command is running")
+			}
+			store := secrets.NewStore(root)
+			if operation == "init" {
+				if err = recordsecret.Init(store, env); err != nil {
+					return err
+				}
+			} else {
+				ring, err := recordsecret.BeginRotation(store, env)
+				if err != nil {
+					return err
+				}
+				count, err := db.RotateRecordSecrets(ctx, conn, ring)
+				if err != nil {
+					return err
+				}
+				// A full second pass verifies every live ciphertext and key ID before finalization.
+				remaining, err := db.RotateRecordSecrets(ctx, conn, ring)
+				if err != nil {
+					return err
+				}
+				if remaining != 0 {
+					return errors.New("Record secrets changed during offline verification; stop writers and resume")
+				}
+				if err = recordsecret.FinishRotation(store, env, ring); err != nil {
+					return err
+				}
+				if _, err = fmt.Fprintf(stdout, "re-encrypted values: %d\nold keys retained for backup recovery\n", count); err != nil {
+					return err
+				}
+			}
+			_, err = fmt.Fprintln(stdout, "Record key "+operation+" complete")
+			return err
+		}}
+		cmd.Flags().StringVar(&envName, "env", envName, "Environment: development, staging, or production")
+		cmd.Flags().BoolVar(&yes, "yes", false, "Confirm the displayed target")
+		cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show the target without changes")
+		if operation == "rotate" {
+			cmd.Flags().BoolVar(&offline, "offline", false, "Confirm servers and workers are stopped")
+		}
+		parent.AddCommand(cmd)
+	}
+	return parent
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,6 +26,8 @@ import (
 	importsvc "github.com/hapyco/dygo/internal/imports"
 	jobruntime "github.com/hapyco/dygo/internal/jobs/runtime"
 	"github.com/hapyco/dygo/internal/permissions"
+	"github.com/hapyco/dygo/internal/recordsecret"
+	"github.com/hapyco/dygo/internal/secrets"
 	"github.com/hapyco/dygo/internal/server"
 	"github.com/hapyco/dygo/internal/shape"
 	"github.com/hapyco/dygo/internal/studio"
@@ -189,7 +191,28 @@ func newRootCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writ
 		return nil, fmt.Errorf("create root command: %w", err)
 	}
 
+	// Resolve keys only when a Record secret is used. Commands without secrets
+	// do not require a project or a key ring.
+	environment := secrets.EnvironmentDevelopment
+	ctx = recordsecret.WithProvider(ctx, func() (recordsecret.Ring, error) {
+		path, err := workingRootPath()
+		if err != nil {
+			return recordsecret.Ring{}, recordsecret.ErrUnavailable
+		}
+		return recordsecret.Load(secrets.NewStore(path), environment)
+	})
 	root := &cobra.Command{
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			environment = secrets.EnvironmentDevelopment
+			if flag := cmd.Flags().Lookup("env"); flag != nil {
+				parsed, err := secrets.ParseEnvironment(flag.Value.String())
+				if err != nil {
+					return err
+				}
+				environment = parsed
+			}
+			return nil
+		},
 		Use:           "dygo",
 		Short:         "dygo is a metadata-driven business application platform.",
 		SilenceUsage:  true,

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -24,6 +24,7 @@ func newSecretCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Wr
 		},
 	}
 
+	cmd.AddCommand(newRecordKeyCommand(ctx, stdout))
 	cmd.AddCommand(newSecretInitCommand(stdout))
 	cmd.AddCommand(newSecretGetCommand(stdout))
 	cmd.AddCommand(newSecretEditCommand(ctx, stdin, stdout, stderr))

--- a/internal/db/link_values.go
+++ b/internal/db/link_values.go
@@ -23,6 +23,9 @@ func (s RecordStore) linkValueCodec() linkValueCodec {
 }
 
 func (c linkValueCodec) storageValue(ctx context.Context, layout recordLayout, field recordField, raw json.RawMessage) (any, error) {
+	if field.Type == "secret" {
+		return secretStorageValue(ctx, layout, field, raw)
+	}
 	if field.Type != "link" {
 		return recordDBValue(field, raw)
 	}

--- a/internal/db/record_hooks.go
+++ b/internal/db/record_hooks.go
@@ -27,6 +27,7 @@ type RecordHookFunc func(context.Context, RecordHookContext) error
 
 // RecordHookContext contains the Record lifecycle state visible to hooks.
 type RecordHookContext struct {
+	layout    *recordLayout
 	Event     RecordHookEvent
 	Operation string
 
@@ -218,6 +219,7 @@ func mustRegisterRecordHook(err error) {
 
 func newRecordHookContext(event RecordHookEvent, layout recordLayout) RecordHookContext {
 	return RecordHookContext{
+		layout:      &layout,
 		Event:       event,
 		EntityID:    layout.EntityID,
 		AppName:     layout.AppName,

--- a/internal/db/record_secret_rotation.go
+++ b/internal/db/record_secret_rotation.go
@@ -1,0 +1,109 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hapyco/dygo/internal/recordsecret"
+	"github.com/jackc/pgx/v5"
+)
+
+// RecordKeyLock serializes offline key commands. It is deliberately distinct
+// from schema and worker locks. Operators must stop all runtime processes.
+const RecordKeyLock int64 = 0x6479676f736563
+
+// RotateRecordSecrets rewrites storage only: no business Hooks, timestamps, or
+// Activity changes. Rotation changes encryption, not the business value.
+// Each batch commits independently and old keys remain available after failure.
+func RotateRecordSecrets(ctx context.Context, conn *pgx.Conn, ring recordsecret.Ring) (int, error) {
+	reader := NewMetadataReader(conn)
+	entities, err := reader.ListEntities(ctx)
+	if err != nil {
+		return 0, errors.New("load metadata for Record key rotation failed")
+	}
+	total := 0
+	for _, entity := range entities {
+		meta, err := reader.GetEntityMetaByIdentity(ctx, entity.App.Name, entity.Key)
+		if err != nil {
+			return total, errors.New("load Record secret metadata failed")
+		}
+		layout, err := newRecordLayout(meta)
+		if err != nil {
+			return total, err
+		}
+		for _, field := range layout.Fields {
+			if field.Type != "secret" {
+				continue
+			}
+			var after int64
+			for {
+				tx, err := conn.Begin(ctx)
+				if err != nil {
+					return total, errors.New("begin Record key rotation batch failed")
+				}
+				count, last, err := rotateSecretBatch(ctx, tx, layout, field, ring, after)
+				if err != nil {
+					_ = tx.Rollback(ctx)
+					return total, err
+				}
+				if err = tx.Commit(ctx); err != nil {
+					return total, errors.New("commit Record key rotation batch failed")
+				}
+				total += count
+				if last == after {
+					break
+				}
+				after = last
+			}
+		}
+	}
+	return total, nil
+}
+func rotateSecretBatch(ctx context.Context, tx pgx.Tx, layout recordLayout, field recordField, ring recordsecret.Ring, after int64) (int, int64, error) {
+	rows, err := tx.Query(ctx, fmt.Sprintf("SELECT id, %s FROM %s WHERE id > $1 AND %s IS NOT NULL ORDER BY id LIMIT 100 FOR UPDATE", quoteIdent(field.Column), quoteIdent(layout.Table), quoteIdent(field.Column)), after)
+	if err != nil {
+		return 0, after, errors.New("read Record key rotation batch failed")
+	}
+	type item struct {
+		id         int64
+		ciphertext string
+	}
+	items := []item{}
+	for rows.Next() {
+		var row item
+		if rows.Scan(&row.id, &row.ciphertext) != nil {
+			rows.Close()
+			return 0, after, errors.New("read Record secret failed")
+		}
+		items = append(items, row)
+	}
+	err = rows.Err()
+	rows.Close()
+	if err != nil {
+		return 0, after, errors.New("read Record key rotation batch failed")
+	}
+	count := 0
+	for _, row := range items {
+		value, err := ring.Decrypt(secretBinding(layout, field), row.ciphertext)
+		if err != nil {
+			return count, after, err
+		}
+		id, err := recordsecret.CipherKey(row.ciphertext)
+		if err != nil {
+			return count, after, err
+		}
+		if id != ring.Active {
+			ciphertext, err := ring.Encrypt(secretBinding(layout, field), value)
+			if err != nil {
+				return count, after, err
+			}
+			if _, err = tx.Exec(ctx, fmt.Sprintf("UPDATE %s SET %s=$1 WHERE id=$2", quoteIdent(layout.Table), quoteIdent(field.Column)), ciphertext, row.id); err != nil {
+				return count, after, errors.New("write rotated Record secret failed")
+			}
+			count++
+		}
+		after = row.id
+	}
+	return count, after, nil
+}

--- a/internal/db/record_secrets.go
+++ b/internal/db/record_secrets.go
@@ -1,0 +1,281 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hapyco/dygo/internal/recordsecret"
+	"github.com/hapyco/dygo/pkg/dygo"
+	"github.com/jackc/pgx/v5"
+)
+
+func secretBinding(layout recordLayout, field recordField) string {
+	return layout.AppName + "/" + layout.Entity + "/" + field.Name
+}
+func secretStorageValue(ctx context.Context, layout recordLayout, field recordField, raw json.RawMessage) (any, error) {
+	if rawIsNull(raw) {
+		if field.Required {
+			return nil, recordError(RecordErrorValidation, "required field cannot be null", map[string]any{"field": field.Name}, nil)
+		}
+		return nil, nil
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil || value == "" {
+		return nil, recordError(RecordErrorValidation, "secret must be a non-empty string", map[string]any{"field": field.Name}, nil)
+	}
+	ring, err := recordsecret.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if ring.Rotating {
+		return nil, errors.New("Record key rotation is in progress")
+	}
+	return ring.Encrypt(secretBinding(layout, field), value)
+}
+
+// DecryptSecret is an internal storage primitive. The SDK enforces system access.
+func (s RecordStore) DecryptSecret(ctx context.Context, appName, entity string, id int64, name string) (string, error) {
+	layout, err := s.recordLayoutByIdentity(ctx, appName, entity)
+	if err != nil {
+		return "", err
+	}
+	field, ok := layout.FieldByName[name]
+	if !ok || field.Type != "secret" {
+		return "", recordError(RecordErrorInvalidRequest, "field is not a secret", nil, nil)
+	}
+	var ciphertext *string
+	// Collection rows are accessible here only through the explicit system SDK.
+	err = s.queryer.QueryRow(ctx, fmt.Sprintf("SELECT %s FROM %s WHERE id = $1", quoteIdent(field.Column), quoteIdent(layout.Table)), id).Scan(&ciphertext)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", recordError(RecordErrorNotFound, "record not found", nil, nil)
+	}
+	if err != nil {
+		return "", errors.New("read Record secret failed")
+	}
+	if ciphertext == nil {
+		return "", dygo.ErrSecretUnset
+	}
+	ring, err := recordsecret.FromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	return ring.Decrypt(secretBinding(layout, field), *ciphertext)
+}
+
+func (s RecordStore) SecretStatus(ctx context.Context, entity string, id int64) (dygo.SecretStatus, error) {
+	layout, err := s.recordLayout(ctx, entity)
+	if err != nil {
+		return dygo.SecretStatus{}, err
+	}
+	return s.secretStatus(ctx, layout, id)
+}
+func (s RecordStore) SecretStatusByIdentity(ctx context.Context, appName, entity string, id int64) (dygo.SecretStatus, error) {
+	layout, err := s.recordLayoutByIdentity(ctx, appName, entity)
+	if err != nil {
+		return dygo.SecretStatus{}, err
+	}
+	return s.secretStatus(ctx, layout, id)
+}
+func (s RecordStore) secretStatus(ctx context.Context, layout recordLayout, id int64) (dygo.SecretStatus, error) {
+	record, err := s.getRecordWithLayout(ctx, layout, id)
+	if err != nil {
+		return dygo.SecretStatus{}, err
+	}
+	// TODO: batch presence projections if Entities gain many secret fields.
+	result := dygo.SecretStatus{Fields: map[string]bool{}, Collections: map[string]map[int64]map[string]bool{}}
+	for _, field := range layout.Fields {
+		if field.Type != "secret" {
+			continue
+		}
+		if err := s.AuthorizeField(ctx, layout.AppName, layout.Entity, id, field.Name, false); err != nil {
+			var denied RecordError
+			if errors.As(err, &denied) && denied.Code == RecordErrorPermissionDenied {
+				continue
+			}
+			return result, err
+		}
+		where, args := s.scopedReadWhere("id = $1", []any{id}, []string{field.Name})
+		var present bool
+		err = s.queryer.QueryRow(ctx, fmt.Sprintf("SELECT %s IS NOT NULL FROM %s AS %s WHERE %s", quoteIdent(field.Column), quoteIdent(layout.Table), quoteIdent(recordSelectSourceAlias), where), args...).Scan(&present)
+		if errors.Is(err, pgx.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return result, errors.New("read secret status failed")
+		}
+		result.Fields[field.Name] = present
+	}
+	for name, collection := range layout.Collections {
+		if _, visible := record[name]; !visible {
+			continue
+		}
+		fields := []recordField{}
+		for _, field := range collection.Layout.Fields {
+			if field.Type == "secret" {
+				fields = append(fields, field)
+			}
+		}
+		if len(fields) == 0 {
+			continue
+		}
+		if err := s.AuthorizeField(ctx, layout.AppName, layout.Entity, id, name, false); err != nil {
+			var denied RecordError
+			if errors.As(err, &denied) && denied.Code == RecordErrorPermissionDenied {
+				continue
+			}
+			return result, err
+		}
+		selectSQL := "id"
+		for _, field := range fields {
+			selectSQL += ", " + quoteIdent(field.Column) + " IS NOT NULL"
+		}
+		rows, err := s.queryer.Query(ctx, fmt.Sprintf("SELECT %s FROM %s WHERE parent_entity_id=$1 AND parent_record_id=$2 AND parent_field_id=$3 ORDER BY ordinal", selectSQL, quoteIdent(collection.Layout.Table)), layout.EntityID, id, collection.Field.ID)
+		if err != nil {
+			return result, errors.New("read collection secret status failed")
+		}
+		statuses := map[int64]map[string]bool{}
+		for rows.Next() {
+			values, err := rows.Values()
+			if err != nil {
+				rows.Close()
+				return result, errors.New("read secret status failed")
+			}
+			rowID := values[0].(int64)
+			statuses[rowID] = map[string]bool{}
+			for i, f := range fields {
+				statuses[rowID][f.Name] = values[i+1].(bool)
+			}
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil {
+			return result, errors.New("read secret status failed")
+		}
+		result.Collections[name] = statuses
+	}
+	return result, nil
+}
+
+// hiddenHookInput keeps submitted secrets out of ordinary Hook maps. Collections
+// with submitted secrets retain their row positions while Hooks edit other values.
+func hiddenHookInput(layout recordLayout, original RecordInput) (RecordInput, func() error, error) {
+	if !layoutHasSecrets(layout) {
+		return original, func() error { return nil }, nil
+	}
+	clean := cloneRecordInput(original)
+	restorers := []func() error{}
+	for _, field := range layout.Fields {
+		if field.Type == "secret" {
+			delete(clean, field.Name)
+		}
+	}
+	for name, collection := range layout.Collections {
+		if !layoutHasSecrets(*collection.Layout) {
+			continue
+		}
+		raw, exists := original[name]
+		if !exists {
+			continue
+		}
+		var rows []RecordInput
+		if json.Unmarshal(raw, &rows) != nil {
+			return nil, nil, recordError(RecordErrorValidation, "collection field must be an array", map[string]any{"field": name}, nil)
+		}
+		cleaned := make([]RecordInput, len(rows))
+		restoreRows := make([]func() error, len(rows))
+		for i, row := range rows {
+			var err error
+			cleaned[i], restoreRows[i], err = hiddenHookInput(*collection.Layout, row)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		clean[name], _ = json.Marshal(cleaned)
+		restorers = append(restorers, func() error {
+			var next []RecordInput
+			if json.Unmarshal(clean[name], &next) != nil || len(next) != len(rows) {
+				return recordError(RecordErrorValidation, "Hooks cannot change submitted collection row structure", map[string]any{"field": name}, nil)
+			}
+			for i, row := range next {
+				if string(row["id"]) != string(rows[i]["id"]) {
+					return recordError(RecordErrorValidation, "Hooks cannot reorder submitted collection rows", map[string]any{"field": name}, nil)
+				}
+				for key := range cleaned[i] {
+					delete(cleaned[i], key)
+				}
+				for key, value := range row {
+					cleaned[i][key] = value
+				}
+				if err := restoreRows[i](); err != nil {
+					return err
+				}
+			}
+			clean[name], _ = json.Marshal(rows)
+			return nil
+		})
+	}
+	return clean, func() error {
+		if err := rejectHookSecrets(layout, clean); err != nil {
+			return err
+		}
+		for _, restore := range restorers {
+			if err := restore(); err != nil {
+				return err
+			}
+		}
+		for name := range original {
+			if layout.FieldByName[name].Type != "secret" {
+				delete(original, name)
+			}
+		}
+		for name, value := range clean {
+			original[name] = value
+		}
+		return nil
+	}, nil
+}
+
+func layoutHasSecrets(layout recordLayout) bool {
+	for _, field := range layout.Fields {
+		if field.Type == "secret" {
+			return true
+		}
+	}
+	for _, collection := range layout.Collections {
+		if layoutHasSecrets(*collection.Layout) {
+			return true
+		}
+	}
+	return false
+}
+
+func rejectHookSecrets(layout recordLayout, input RecordInput) error {
+	for _, field := range layout.Fields {
+		if field.Type == "secret" {
+			if _, exists := input[field.Name]; exists {
+				return recordError(RecordErrorValidation, "Hooks cannot submit secret fields", map[string]any{"field": field.Name}, nil)
+			}
+		}
+	}
+	for name, collection := range layout.Collections {
+		if !layoutHasSecrets(*collection.Layout) {
+			continue
+		}
+		raw, exists := input[name]
+		if !exists {
+			continue
+		}
+		var rows []RecordInput
+		if json.Unmarshal(raw, &rows) != nil {
+			return recordError(RecordErrorValidation, "collection field must be an array", map[string]any{"field": name}, nil)
+		}
+		for _, row := range rows {
+			if err := rejectHookSecrets(*collection.Layout, row); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/db/record_secrets_test.go
+++ b/internal/db/record_secrets_test.go
@@ -1,0 +1,272 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hapyco/dygo/internal/entity/fieldtype"
+	"github.com/hapyco/dygo/internal/entity/schema"
+	"github.com/hapyco/dygo/internal/recordsecret"
+	"github.com/hapyco/dygo/internal/secrets"
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+func secretTestContext(t *testing.T) (context.Context, secrets.Store) {
+	t.Helper()
+	store := secrets.NewStore(t.TempDir())
+	if _, err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := recordsecret.Init(store, secrets.EnvironmentDevelopment); err != nil {
+		t.Fatal(err)
+	}
+	return recordsecret.WithStore(context.Background(), store, secrets.EnvironmentDevelopment), store
+}
+func TestSecretStorageValidation(t *testing.T) {
+	ctx, _ := secretTestContext(t)
+	layout := recordLayout{AppName: "test", Entity: "account"}
+	field := recordField{Name: "token", Type: "secret"}
+	for _, raw := range []string{`""`, `123`, `{"value":"sensitive"}`} {
+		if _, err := secretStorageValue(ctx, layout, field, json.RawMessage(raw)); err == nil || strings.Contains(err.Error(), "sensitive") {
+			t.Fatal("invalid input accepted or exposed")
+		}
+	}
+	if v, err := secretStorageValue(ctx, layout, field, json.RawMessage(`null`)); err != nil || v != nil {
+		t.Fatal("clear failed")
+	}
+	field.Required = true
+	if _, err := secretStorageValue(ctx, layout, field, json.RawMessage(`null`)); err == nil {
+		t.Fatal("required clear accepted")
+	}
+	if _, err := secretStorageValue(context.Background(), layout, field, json.RawMessage(`"value"`)); err == nil {
+		t.Fatal("missing keys accepted")
+	}
+}
+func TestSecretHookInputs(t *testing.T) {
+	child := recordLayout{Fields: []recordField{{Name: "token", Type: "secret"}}, FieldByName: map[string]recordField{"token": {Name: "token", Type: "secret"}}}
+	layout := child
+	layout.Collections = map[string]recordCollection{"rows": {Layout: &child}}
+	input := RecordInput{"token": json.RawMessage(`"parent-value"`), "note": json.RawMessage(`"old"`), "rows": json.RawMessage(`[{"id":1,"token":"child-value","note":"old"}]`)}
+	clean, restore, err := hiddenHookInput(layout, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(clean)
+	if strings.Contains(string(raw), "value") {
+		t.Fatal("Hook received a secret")
+	}
+	clean["note"] = json.RawMessage(`"changed"`)
+	clean["rows"] = json.RawMessage(`[{"id":1,"note":"changed"}]`)
+	if err = restore(); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = json.Marshal(input)
+	if !strings.Contains(string(raw), "parent-value") || !strings.Contains(string(raw), "child-value") || !strings.Contains(string(raw), "changed") {
+		t.Fatal("lost submitted values or Hook edits")
+	}
+	clean, restore, _ = hiddenHookInput(layout, input)
+	clean["token"] = json.RawMessage(`"injected"`)
+	if err = restore(); err == nil {
+		t.Fatal("Hook injection accepted")
+	}
+	clean, restore, _ = hiddenHookInput(layout, input)
+	clean["rows"] = json.RawMessage(`[{"id":1,"token":"injected"}]`)
+	if err = restore(); err == nil {
+		t.Fatal("nested Hook injection accepted")
+	}
+	empty := RecordInput{}
+	clean, restore, _ = hiddenHookInput(layout, empty)
+	clean["rows"] = json.RawMessage(`[{"token":"injected"}]`)
+	if err = restore(); err == nil {
+		t.Fatal("new collection Hook injection accepted")
+	}
+
+}
+func TestPostgresSecretLifecycleAndRotation(t *testing.T) {
+	pool, metadata := auditDatabase(t)
+	parent := auditEntity("vault", schema.Field{Name: "token", Label: "Token", Type: "secret", Required: true}, schema.Field{Name: "optional", Label: "Optional", Type: "secret"}, schema.Field{Name: "note", Label: "Note", Type: "text"}, schema.Field{Name: "rows", Label: "Rows", Type: "collection", Options: fieldtype.Options{Entity: "vault-row"}})
+	child := auditEntity("vault-row", schema.Field{Name: "token", Label: "Token", Type: "secret", Required: true})
+	child.Entity.IsCollection = true
+	single := auditEntity("vault-settings", schema.Field{Name: "token", Label: "Token", Type: "secret"})
+	single.Entity.IsSingle = true
+	single.Entity.Naming = schema.Naming{}
+	metadata.Entities = append(metadata.Entities, parent, child, single)
+	syncAuditMetadata(t, pool, metadata)
+	ctx, keys := secretTestContext(t)
+	hooks := NewRecordHookRegistry()
+	if err := hooks.RegisterEntity("audit", "vault", RecordBeforeValidate, "check-hidden", func(_ context.Context, h RecordHookContext) error {
+		raw, _ := json.Marshal(h.Input)
+		if strings.Contains(string(raw), "private-value") {
+			return errors.New("secret leaked to Hook")
+		}
+		h.Input["note"] = json.RawMessage(`"hooked"`)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store := NewRecordStoreWithHooks(pool, hooks)
+	record, err := store.CreateRecordByIdentity(ctx, "audit", "vault", recordInput(map[string]string{"name": `"one"`, "token": `"private-value"`, "optional": `"optional-value"`, "rows": `[{"token":"child-private-value"}]`}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := record["id"].(int64)
+	raw, _ := json.Marshal(record)
+	if strings.Contains(string(raw), "private-value") || strings.Contains(string(raw), "encrypted") {
+		t.Fatal("response leaked secret")
+	}
+	if record["note"] != "hooked" {
+		t.Fatal("Hook edit lost")
+	}
+	var ciphertext string
+	if err = pool.QueryRow(ctx, `SELECT token_encrypted FROM audit_vault WHERE id=$1`, id).Scan(&ciphertext); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(ciphertext, "private-value") {
+		t.Fatal("plaintext stored")
+	}
+	value, err := store.DecryptSecret(ctx, "audit", "vault", id, "token")
+	if err != nil || value != "private-value" {
+		t.Fatalf("decrypt failed: %v", err)
+	}
+	status, err := store.SecretStatusByIdentity(ctx, "audit", "vault", id)
+	if err != nil || !status.Fields["token"] || len(status.Collections["rows"]) != 1 {
+		t.Fatalf("status: %+v %v", status, err)
+	}
+	for childID := range status.Collections["rows"] {
+		if value, err = store.DecryptSecret(ctx, "audit", "vault-row", childID, "token"); err != nil || value != "child-private-value" {
+			t.Fatal("child decrypt failed")
+		}
+		if _, err = store.UpdateRecordByIdentity(ctx, "audit", "vault", id, recordInput(map[string]string{"rows": fmt.Sprintf(`[{"id":%d}]`, childID)})); err != nil {
+			t.Fatal(err)
+		}
+	}
+	scoped := store.WithScope(RecordScope{Where: "TRUE", FieldRead: map[string]string{"token": "FALSE", "rows": "FALSE"}})
+	status, err = scoped.SecretStatusByIdentity(ctx, "audit", "vault", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := status.Fields["token"]; ok || len(status.Collections) != 0 {
+		t.Fatal("presence bypassed field access")
+	}
+	if _, err = store.WithScope(RecordScope{Where: "FALSE"}).SecretStatusByIdentity(ctx, "audit", "vault", id); err == nil {
+		t.Fatal("presence bypassed row access")
+	}
+	if _, err = store.UpdateRecordByIdentity(ctx, "audit", "vault", id, recordInput(map[string]string{"token": `null`})); err == nil {
+		t.Fatal("required clear accepted")
+	}
+	if _, err = store.UpdateRecordByIdentity(ctx, "audit", "vault", id, recordInput(map[string]string{"optional": `null`})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.DecryptSecret(ctx, "audit", "vault", id, "optional"); !errors.Is(err, dygo.ErrSecretUnset) {
+		t.Fatal("unset error missing")
+	}
+	// A transaction rollback restores the old ciphertext.
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = NewRecordStoreWithHookPolicy(tx, RecordMutationHooksNone).UpdateRecordByIdentity(ctx, "audit", "vault", id, recordInput(map[string]string{"token": `"rollback-value"`})); err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.Rollback(ctx)
+	if value, err = store.DecryptSecret(ctx, "audit", "vault", id, "token"); err != nil || value != "private-value" {
+		t.Fatal("rollback lost secret")
+	}
+	if _, err = store.UpdateSingleRecord(ctx, "vault-settings", recordInput(map[string]string{"token": `"single-private-value"`})); err != nil {
+		t.Fatal(err)
+	}
+	ring, err := recordsecret.BeginRotation(keys, secrets.EnvironmentDevelopment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.UpdateRecordByIdentity(ctx, "audit", "vault", id, recordInput(map[string]string{"token": `"blocked"`})); err == nil {
+		t.Fatal("write during rotation accepted")
+	}
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+	changed, err := RotateRecordSecrets(ctx, conn.Conn(), ring)
+	if err != nil || changed != 3 {
+		t.Fatalf("rotate changed=%d error=%v", changed, err)
+	}
+	changed, err = RotateRecordSecrets(ctx, conn.Conn(), ring)
+	if err != nil || changed != 0 {
+		t.Fatalf("resume changed=%d error=%v", changed, err)
+	}
+	if err = recordsecret.FinishRotation(keys, secrets.EnvironmentDevelopment, ring); err != nil {
+		t.Fatal(err)
+	}
+	if value, err = store.DecryptSecret(ctx, "audit", "vault", id, "token"); err != nil || value != "private-value" {
+		t.Fatal("rotation lost secret")
+	}
+	if value, err = ring.Decrypt("audit/vault/token", ciphertext); err != nil || value != "private-value" {
+		t.Fatal("backup key lost")
+	}
+}
+
+func TestPostgresSecretRotationResumesCommittedBatches(t *testing.T) {
+	pool, metadata := auditDatabase(t)
+	metadata.Entities = append(metadata.Entities, auditEntity("rotate", schema.Field{Name: "token", Label: "Token", Type: "secret"}))
+	syncAuditMetadata(t, pool, metadata)
+	ctx, keys := secretTestContext(t)
+	ring, err := recordsecret.Load(keys, secrets.EnvironmentDevelopment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old, err := ring.Encrypt("audit/rotate/token", "private-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO audit_rotate(name,token_encrypted) SELECT 'row-'||i, $1 FROM generate_series(1,101) i`, old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `UPDATE audit_rotate SET token_encrypted='invalid' WHERE id=101`); err != nil {
+		t.Fatal(err)
+	}
+	ring, err = recordsecret.BeginRotation(keys, secrets.EnvironmentDevelopment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+	var locked bool
+	if err = conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, RecordKeyLock).Scan(&locked); err != nil || !locked {
+		t.Fatal("lock failed")
+	}
+	second, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Release()
+	if err = second.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, RecordKeyLock).Scan(&locked); err != nil || locked {
+		t.Fatal("concurrent rotation lock accepted")
+	}
+	changed, err := RotateRecordSecrets(ctx, conn.Conn(), ring)
+	if err == nil || changed != 100 {
+		t.Fatalf("expected committed first batch and corrupt second batch: %d %v", changed, err)
+	}
+	if _, err = pool.Exec(ctx, `UPDATE audit_rotate SET token_encrypted=$1 WHERE id=101`, old); err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := recordsecret.BeginRotation(keys, secrets.EnvironmentDevelopment)
+	if err != nil || resumed.Active != ring.Active {
+		t.Fatal("resume changed key")
+	}
+	changed, err = RotateRecordSecrets(ctx, conn.Conn(), resumed)
+	if err != nil || changed != 1 {
+		t.Fatalf("resume failed: %d %v", changed, err)
+	}
+	var count int
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM audit_rotate WHERE token_encrypted::jsonb->>'key'=$1`, ring.Active).Scan(&count); err != nil || count != 101 {
+		t.Fatal("not all ciphertexts rotated")
+	}
+}

--- a/internal/db/records.go
+++ b/internal/db/records.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hapyco/dygo/internal/entity/schema"
 	"github.com/hapyco/dygo/internal/recordfilter"
 	"github.com/hapyco/dygo/internal/recordquery"
+	"github.com/hapyco/dygo/internal/recordsecret"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"golang.org/x/crypto/bcrypt"
@@ -338,6 +339,7 @@ func (s RecordStore) UpdateSingleRecord(ctx context.Context, entity string, inpu
 	if err := s.requireQueryer(); err != nil {
 		return nil, err
 	}
+	ctx = recordsecret.WithOperation(ctx)
 	return s.withRecordMutation(ctx, func(store RecordStore) (Record, error) {
 		layout, err := store.recordLayout(ctx, entity)
 		if err != nil {
@@ -413,6 +415,7 @@ func (s RecordStore) CreateRecord(ctx context.Context, entity string, input Reco
 	if err := s.requireQueryer(); err != nil {
 		return nil, err
 	}
+	ctx = recordsecret.WithOperation(ctx)
 	return s.withRecordMutation(ctx, func(store RecordStore) (Record, error) {
 		return store.createRecord(ctx, entity, input)
 	})
@@ -423,6 +426,7 @@ func (s RecordStore) CreateRecordByIdentity(ctx context.Context, appName string,
 	if err := s.requireQueryer(); err != nil {
 		return nil, err
 	}
+	ctx = recordsecret.WithOperation(ctx)
 	return s.withRecordMutation(ctx, func(store RecordStore) (Record, error) {
 		return store.createRecordByIdentity(ctx, appName, entity, input)
 	})
@@ -562,6 +566,7 @@ func (s RecordStore) UpdateRecord(ctx context.Context, entity string, id int64, 
 	if id <= 0 {
 		return nil, invalidRecordIDError(entity)
 	}
+	ctx = recordsecret.WithOperation(ctx)
 	return s.withRecordMutation(ctx, func(store RecordStore) (Record, error) {
 		return store.updateRecord(ctx, entity, id, input)
 	})
@@ -575,6 +580,7 @@ func (s RecordStore) UpdateRecordByIdentity(ctx context.Context, appName string,
 	if id <= 0 {
 		return nil, invalidRecordIDError(recordIdentityName(appName, entity))
 	}
+	ctx = recordsecret.WithOperation(ctx)
 	return s.withRecordMutation(ctx, func(store RecordStore) (Record, error) {
 		return store.updateRecordByIdentity(ctx, appName, entity, id, input)
 	})

--- a/internal/db/records.go
+++ b/internal/db/records.go
@@ -917,7 +917,18 @@ func (s RecordStore) runRecordHooks(ctx context.Context, hookCtx RecordHookConte
 	}
 	hookCtx.Queryer = s.queryer
 	hookCtx.LogQueryer = s.logQueryer
-	return s.hooks.Run(ctx, hookCtx)
+	if hookCtx.layout == nil {
+		return s.hooks.Run(ctx, hookCtx)
+	}
+	clean, restore, err := hiddenHookInput(*hookCtx.layout, hookCtx.Input)
+	if err != nil {
+		return err
+	}
+	hookCtx.Input = clean
+	if err := s.hooks.Run(ctx, hookCtx); err != nil {
+		return err
+	}
+	return restore()
 }
 
 type recordLayout struct {
@@ -1590,6 +1601,9 @@ func (l recordLayout) validateInputFields(input RecordInput, create bool, match 
 				continue
 			}
 			return recordError(RecordErrorValidation, "field is not supported by record runtime", map[string]any{"entity": l.Entity, "field": name}, nil)
+		}
+		if match && field.Type == "secret" {
+			return recordError(RecordErrorValidation, "write-only field cannot be used for matching", map[string]any{"field": name}, nil)
 		}
 		if rawIsNull(raw) && field.Required {
 			return recordError(RecordErrorValidation, "required field cannot be null", map[string]any{"entity": l.Entity, "field": name}, nil)

--- a/internal/db/schema_plan.go
+++ b/internal/db/schema_plan.go
@@ -395,14 +395,14 @@ func buildDesiredSchema(entities []catalog.LoadedEntity) (desiredSchema, error) 
 					definition += " DEFAULT " + value
 				}
 			}
-			if field.Required {
+			if field.Required && field.Type != "secret" {
 				definition += " NOT NULL"
 			}
 			desiredTable.Columns = append(desiredTable.Columns, desiredColumn{
 				Name:           column,
 				Type:           sqlType,
-				Required:       field.Required,
-				HasSafeDefault: !field.Required || hasDefault && hasSafeDefault,
+				Required:       field.Required && field.Type != "secret",
+				HasSafeDefault: field.Type == "secret" || !field.Required || hasDefault && hasSafeDefault,
 				DefaultSQL:     defaultSQL,
 				Definition:     definition,
 				Source:         fieldSource(loaded, field),

--- a/internal/db/system_records.go
+++ b/internal/db/system_records.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+
+	"github.com/hapyco/dygo/internal/recordsecret"
 )
 
 // SystemMutationPolicy declares which public Record behavior an internal writer should use.
@@ -102,6 +104,7 @@ func (w SystemRecordWriter) upsertByIdentity(ctx context.Context, appName string
 	if err != nil {
 		return nil, err
 	}
+	ctx = recordsecret.WithOperation(ctx)
 	record, err := store.withRecordMutation(ctx, func(txStore RecordStore) (Record, error) {
 		existing, err := txStore.FindRecordByIdentity(ctx, appName, entity, match)
 		if err != nil {

--- a/internal/dygodata/records.go
+++ b/internal/dygodata/records.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hapyco/dygo/internal/db"
 	"github.com/hapyco/dygo/internal/permissions"
+	"github.com/hapyco/dygo/internal/recordsecret"
 	"github.com/hapyco/dygo/pkg/dygo"
 	"github.com/jackc/pgx/v5"
 )
@@ -77,7 +78,8 @@ func (d RecordData) context(ctx context.Context) context.Context {
 	} else if d.actor != nil {
 		ctx = db.WithActivityActor(ctx, d.actor.UserID, d.actor.Email, d.actor.Administrator)
 	}
-	return db.WithActivitySystemReason(ctx, d.systemReason)
+	ctx = db.WithActivitySystemReason(ctx, d.systemReason)
+	return recordsecret.WithOperation(ctx)
 }
 
 // List returns a page of Records by app/entity identity.

--- a/internal/dygodata/secrets.go
+++ b/internal/dygodata/secrets.go
@@ -26,12 +26,13 @@ func (d RecordData) DecryptSecret(ctx context.Context, appName, entity string, i
 	if a, ok := db.ActivityActorFromContext(ctx); ok {
 		actor = a.Email
 	}
-	writer := dygo.LogWriter(NewLogData(d.queryer))
-	if contextual, ok := dygo.LogWriterFromContext(ctx); ok {
-		writer = contextual
-	}
-	logErr := writer.WriteLog(ctx, dygo.LogEntry{Type: dygo.TypeInfo, Source: dygo.SourceSDK, Title: "Record secret decryption", App: appName, Actor: actor, ReferenceEntity: appName + "." + entity, ReferenceRecordID: id, Metadata: map[string]any{"field": field, "reason": d.systemReason, "outcome": outcome}})
+	// Keep this sink framework-owned. Public LogWriter context values are app
+	// observability hooks and must not be able to suppress the security audit.
+	logErr := NewLogData(d.queryer).WriteLog(ctx, dygo.LogEntry{Type: dygo.TypeInfo, Source: dygo.SourceSDK, Title: "Record secret decryption", App: appName, Actor: actor, ReferenceEntity: appName + "." + entity, ReferenceRecordID: id, Metadata: map[string]any{"field": field, "reason": d.systemReason, "outcome": outcome}})
 	if logErr != nil {
+		if err != nil {
+			return "", err
+		}
 		return "", errors.New("record secret access audit failed")
 	}
 	return value, err

--- a/internal/dygodata/secrets.go
+++ b/internal/dygodata/secrets.go
@@ -1,0 +1,46 @@
+package dygodata
+
+import (
+	"context"
+	"errors"
+	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/internal/permissions"
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+// DecryptSecret requires explicit system access; ordinary trusted SDK reads cannot reveal secrets.
+func (d RecordData) DecryptSecret(ctx context.Context, appName, entity string, id int64, field string) (string, error) {
+	ctx = d.context(ctx)
+	var value string
+	var err error
+	if !d.systemMode || d.systemReason == "" {
+		err = db.RecordError{Code: db.RecordErrorPermissionDenied, Message: "secret decryption requires explicit system access"}
+	} else {
+		value, err = d.store().DecryptSecret(ctx, appName, entity, id, field)
+	}
+	outcome := "success"
+	if err != nil {
+		outcome = "denied-or-failed"
+	}
+	actor := ""
+	if a, ok := db.ActivityActorFromContext(ctx); ok {
+		actor = a.Email
+	}
+	writer := dygo.LogWriter(NewLogData(d.queryer))
+	if contextual, ok := dygo.LogWriterFromContext(ctx); ok {
+		writer = contextual
+	}
+	logErr := writer.WriteLog(ctx, dygo.LogEntry{Type: dygo.TypeInfo, Source: dygo.SourceSDK, Title: "Record secret decryption", App: appName, Actor: actor, ReferenceEntity: appName + "." + entity, ReferenceRecordID: id, Metadata: map[string]any{"field": field, "reason": d.systemReason, "outcome": outcome}})
+	if logErr != nil {
+		return "", errors.New("record secret access audit failed")
+	}
+	return value, err
+}
+func (d RecordData) SecretStatus(ctx context.Context, appName, entity string, id int64) (dygo.SecretStatus, error) {
+	ctx = d.context(ctx)
+	store, err := d.scopedStore(ctx, appName, entity, permissions.ActionRead)
+	if err != nil {
+		return dygo.SecretStatus{}, err
+	}
+	return store.SecretStatusByIdentity(ctx, appName, entity, id)
+}

--- a/internal/dygodata/secrets_integration_test.go
+++ b/internal/dygodata/secrets_integration_test.go
@@ -1,0 +1,101 @@
+package dygodata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/internal/recordsecret"
+	"github.com/hapyco/dygo/internal/secrets"
+	"github.com/hapyco/dygo/pkg/dygo"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresSDKSecretAccessAndTransaction(t *testing.T) {
+	url := os.Getenv("DYGO_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("set DYGO_TEST_DATABASE_URL to run PostgreSQL regressions")
+	}
+	ctx := context.Background()
+	admin, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+	name := fmt.Sprintf("dygo_secret_sdk_%d", time.Now().UnixNano())
+	if _, err = admin.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{name}.Sanitize()); err != nil {
+		t.Fatal(err)
+	}
+	cfg := admin.Config().Copy()
+	cfg.ConnConfig.Database = name
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		pool.Close()
+		if _, err := admin.Exec(ctx, "DROP DATABASE "+pgx.Identifier{name}.Sanitize()); err != nil {
+			t.Error(err)
+		}
+	}()
+	root, _ := filepath.Abs("../..")
+	if _, err = db.SyncMetadataSchema(ctx, pool, root); err != nil {
+		t.Fatal(err)
+	}
+	// Test-only metadata extends Core User in an isolated database. Production
+	// callers use authored Entity metadata and additive schema sync.
+	if _, err = pool.Exec(ctx, `ALTER TABLE "user" ADD COLUMN token_encrypted text; INSERT INTO field(name,entity_id,field_name,label,type,position) SELECT name||'.token',id,'token','Token','secret',100 FROM entity WHERE name='core.user'`); err != nil {
+		t.Fatal(err)
+	}
+	keys := secrets.NewStore(t.TempDir())
+	if _, err = keys.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err = recordsecret.Init(keys, secrets.EnvironmentDevelopment); err != nil {
+		t.Fatal(err)
+	}
+	ctx = recordsecret.WithStore(ctx, keys, secrets.EnvironmentDevelopment)
+	record, err := db.NewRecordStore(pool).SystemWriter().InsertReturningByIdentity(ctx, "core", "user", db.RecordInput{"email": json.RawMessage(`"secret-test@example.com"`), "full-name": json.RawMessage(`"Secret Test"`), "token": json.RawMessage(`"private-sdk-value"`)}, db.SystemMutationBootstrap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := record["id"].(int64)
+	sdk := NewRecordData(pool, nil).AsSystem("integration-use")
+	value, err := sdk.DecryptSecret(ctx, "core", "user", id, "token")
+	if err != nil || value != "private-sdk-value" {
+		t.Fatalf("SDK decrypt failed: %v", err)
+	}
+	var audit string
+	if err = pool.QueryRow(ctx, `SELECT metadata::text FROM log WHERE title='Record secret decryption' ORDER BY id DESC LIMIT 1`).Scan(&audit); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(audit, "integration-use") || strings.Contains(audit, "private-sdk-value") {
+		t.Fatal("incorrect audit")
+	}
+	sentinel := errors.New("rollback")
+	err = sdk.Transaction(ctx, func(ctx context.Context, records dygo.RecordData) error {
+		if _, err := records.DecryptSecret(ctx, "core", "user", id, "token"); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("transaction access failed: %v", err)
+	}
+	var count int
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM log WHERE title='Record secret decryption'`).Scan(&count); err != nil || count != 1 {
+		t.Fatal("transaction context was not preserved")
+	}
+	broken := &secretAudit{err: errors.New("audit failure")}
+	if value, err = sdk.DecryptSecret(dygo.WithLogWriter(ctx, broken), "core", "user", id, "token"); err == nil || value != "" {
+		t.Fatal("secret returned without audit")
+	}
+}

--- a/internal/dygodata/secrets_integration_test.go
+++ b/internal/dygodata/secrets_integration_test.go
@@ -95,7 +95,13 @@ func TestPostgresSDKSecretAccessAndTransaction(t *testing.T) {
 		t.Fatal("transaction context was not preserved")
 	}
 	broken := &secretAudit{err: errors.New("audit failure")}
-	if value, err = sdk.DecryptSecret(dygo.WithLogWriter(ctx, broken), "core", "user", id, "token"); err == nil || value != "" {
-		t.Fatal("secret returned without audit")
+	if value, err = sdk.DecryptSecret(dygo.WithLogWriter(ctx, broken), "core", "user", id, "token"); err != nil || value != "private-sdk-value" {
+		t.Fatalf("public LogWriter changed framework audit behavior: %v", err)
+	}
+	if len(broken.entries) != 0 {
+		t.Fatal("public LogWriter received the security audit")
+	}
+	if err = pool.QueryRow(ctx, `SELECT count(*) FROM log WHERE title='Record secret decryption'`).Scan(&count); err != nil || count != 2 {
+		t.Fatal("framework audit was not persisted")
 	}
 }

--- a/internal/dygodata/secrets_test.go
+++ b/internal/dygodata/secrets_test.go
@@ -29,8 +29,8 @@ func TestSecretDecryptRequiresExplicitSystem(t *testing.T) {
 		if value != "" || !errors.As(err, &denied) || denied.Code != db.RecordErrorPermissionDenied {
 			t.Fatalf("access was not denied: %v", err)
 		}
-		if len(audit.entries) != 1 || audit.entries[0].Metadata["outcome"] != "denied-or-failed" {
-			t.Fatal("denial not audited")
+		if len(audit.entries) != 0 {
+			t.Fatal("public LogWriter replaced the framework audit sink")
 		}
 		raw, _ := json.Marshal(audit.entries)
 		if strings.Contains(string(raw), "ciphertext") {

--- a/internal/dygodata/secrets_test.go
+++ b/internal/dygodata/secrets_test.go
@@ -1,0 +1,40 @@
+package dygodata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hapyco/dygo/internal/db"
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+type secretAudit struct {
+	entries []dygo.LogEntry
+	err     error
+}
+
+func (s *secretAudit) WriteLog(_ context.Context, entry dygo.LogEntry) error {
+	s.entries = append(s.entries, entry)
+	return s.err
+}
+func TestSecretDecryptRequiresExplicitSystem(t *testing.T) {
+	for _, view := range []dygo.RecordData{NewRecordData(nil, nil), NewRecordData(nil, nil).AsActor(dygo.Actor{UserID: 1, Administrator: true}), NewRecordData(nil, nil).AsSystem(" "), NewRecordData(nil, nil).AsSystem("job").AsActor(dygo.Actor{Administrator: true})} {
+		audit := &secretAudit{}
+		ctx := dygo.WithLogWriter(context.Background(), audit)
+		value, err := view.DecryptSecret(ctx, "app", "account", 1, "token")
+		var denied db.RecordError
+		if value != "" || !errors.As(err, &denied) || denied.Code != db.RecordErrorPermissionDenied {
+			t.Fatalf("access was not denied: %v", err)
+		}
+		if len(audit.entries) != 1 || audit.entries[0].Metadata["outcome"] != "denied-or-failed" {
+			t.Fatal("denial not audited")
+		}
+		raw, _ := json.Marshal(audit.entries)
+		if strings.Contains(string(raw), "ciphertext") {
+			t.Fatal("audit exposed ciphertext")
+		}
+	}
+}

--- a/internal/entity/fieldtype/builtins.go
+++ b/internal/entity/fieldtype/builtins.go
@@ -18,6 +18,11 @@ func builtIns() []Definition {
 
 		// Sensitive fields.
 		{
+			Name: "secret", Label: "Secret", AllowRequired: true,
+			Behavior: Behavior{Stored: true, ColumnSuffix: "_encrypted", SQLType: "text", ValueKind: "secret", WriteOnly: true, StudioEditor: "secret", StudioDisplay: "hidden"},
+			Validate: NoOptions,
+		},
+		{
 			Name:          "password",
 			Label:         "Password",
 			AllowRequired: true,

--- a/internal/entity/schema/secret_test.go
+++ b/internal/entity/schema/secret_test.go
@@ -1,0 +1,23 @@
+package schema
+
+import (
+	"github.com/hapyco/dygo/internal/entity/fieldtype"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestSecretMetadataRestrictions(t *testing.T) {
+	for _, option := range []string{"", "index: true", "unique: true", "default: private-value"} {
+		var entity Entity
+		err := yaml.Unmarshal([]byte("label: Connection\nfields:\n  - name: token\n    label: Token\n    type: secret\n    "+option+"\n"), &entity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entity.Name = "connection"
+		entity.Naming = Naming{Strategy: NamingStrategyRandom}
+		err = entity.Validate(fieldtype.DefaultRegistry())
+		if (err == nil) != (option == "") {
+			t.Fatalf("option %q: %v", option, err)
+		}
+	}
+}

--- a/internal/fixtures/fixtures.go
+++ b/internal/fixtures/fixtures.go
@@ -449,6 +449,9 @@ func validateFixtureRecords(file LoadedFile, entity catalog.LoadedEntity, index 
 }
 
 func validateFixtureValue(path string, value Value, owner catalog.LoadedEntity, field fixtureField, index catalog.TargetIndex, depth int) error {
+	if field.Type == "secret" {
+		return fmt.Errorf("secret values are not allowed in Fixtures")
+	}
 	if field.Type != "link" {
 		return nil
 	}

--- a/internal/fixtures/secret_test.go
+++ b/internal/fixtures/secret_test.go
@@ -1,0 +1,14 @@
+package fixtures
+
+import (
+	"github.com/hapyco/dygo/internal/entity/catalog"
+	"strings"
+	"testing"
+)
+
+func TestSecretFixtureValueRejected(t *testing.T) {
+	err := validateFixtureValue("fixture.yml", Value{}, catalog.LoadedEntity{}, fixtureField{Name: "token", Type: "secret"}, catalog.TargetIndex{}, 0)
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("secret fixture accepted: %v", err)
+	}
+}

--- a/internal/recordsecret/recordsecret.go
+++ b/internal/recordsecret/recordsecret.go
@@ -1,0 +1,214 @@
+// Package recordsecret owns Record encryption and its environment key ring.
+package recordsecret
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"filippo.io/age"
+	"github.com/hapyco/dygo/internal/secrets"
+)
+
+const configKey = "_record_encryption"
+
+var ErrUnavailable = errors.New("Record encryption key is unavailable")
+var ErrInvalid = errors.New("Record secret ciphertext is invalid")
+
+type Ring struct {
+	Active   string            `json:"active"`
+	Keys     map[string]string `json:"keys"`
+	Rotating bool              `json:"rotating,omitempty"`
+}
+type envelope struct {
+	Version int    `json:"v"`
+	Key     string `json:"key"`
+	Data    string `json:"data"`
+}
+type payload struct {
+	Binding string `json:"binding"`
+	Value   string `json:"value"`
+}
+type contextKey struct{}
+type Provider func() (Ring, error)
+
+func WithProvider(ctx context.Context, provider Provider) context.Context {
+	return context.WithValue(ctx, contextKey{}, provider)
+}
+func WithStore(ctx context.Context, store secrets.Store, env secrets.Environment) context.Context {
+	return WithProvider(ctx, func() (Ring, error) { return Load(store, env) })
+}
+func FromContext(ctx context.Context) (Ring, error) {
+	p, ok := ctx.Value(contextKey{}).(Provider)
+	if !ok {
+		return Ring{}, ErrUnavailable
+	}
+	return p()
+}
+func Load(store secrets.Store, env secrets.Environment) (Ring, error) {
+	doc, err := store.Load(env)
+	if err != nil {
+		return Ring{}, ErrUnavailable
+	}
+	value, ok := doc.Values[configKey]
+	if !ok {
+		return Ring{}, ErrUnavailable
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return Ring{}, ErrUnavailable
+	}
+	var ring Ring
+	if json.Unmarshal(raw, &ring) != nil || ring.validate() != nil {
+		return Ring{}, ErrUnavailable
+	}
+	return ring, nil
+}
+func (r Ring) validate() error {
+	if r.Active == "" || r.Keys[r.Active] == "" {
+		return ErrUnavailable
+	}
+	for id, key := range r.Keys {
+		identity, err := age.ParseX25519Identity(key)
+		if err != nil || keyID(identity) != id {
+			return ErrUnavailable
+		}
+	}
+	return nil
+}
+func save(store secrets.Store, env secrets.Environment, ring Ring) error {
+	doc, err := store.Load(env)
+	if err != nil {
+		return ErrUnavailable
+	}
+	data, err := json.Marshal(ring)
+	if err != nil {
+		return ErrUnavailable
+	}
+	var value map[string]any
+	if json.Unmarshal(data, &value) != nil {
+		return ErrUnavailable
+	}
+	doc.Values[configKey] = value
+	if store.Save(env, doc) != nil {
+		return errors.New("save Record encryption keys failed")
+	}
+	return nil
+}
+func keyID(identity *age.X25519Identity) string {
+	sum := sha256.Sum256([]byte(identity.Recipient().String()))
+	return hex.EncodeToString(sum[:])
+}
+func newKey(ring *Ring) error {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		return ErrUnavailable
+	}
+	if ring.Keys == nil {
+		ring.Keys = map[string]string{}
+	}
+	ring.Active = keyID(identity)
+	ring.Keys[ring.Active] = identity.String()
+	return nil
+}
+
+// Init preserves existing keys, including malformed configuration which needs repair.
+func Init(store secrets.Store, env secrets.Environment) error {
+	doc, err := store.Load(env)
+	if err != nil {
+		return ErrUnavailable
+	}
+	if _, exists := doc.Values[configKey]; exists {
+		_, err = Load(store, env)
+		return err
+	}
+	ring := Ring{}
+	if err = newKey(&ring); err != nil {
+		return err
+	}
+	return save(store, env, ring)
+}
+
+// BeginRotation resumes an incomplete rotation without generating another key.
+func BeginRotation(store secrets.Store, env secrets.Environment) (Ring, error) {
+	ring, err := Load(store, env)
+	if err != nil {
+		return Ring{}, err
+	}
+	if ring.Rotating {
+		return ring, nil
+	}
+	if err = newKey(&ring); err != nil {
+		return Ring{}, err
+	}
+	ring.Rotating = true
+	return ring, save(store, env, ring)
+}
+func FinishRotation(store secrets.Store, env secrets.Environment, ring Ring) error {
+	ring.Rotating = false
+	return save(store, env, ring)
+}
+func (r Ring) Encrypt(binding, value string) (string, error) {
+	if value == "" {
+		return "", errors.New("secret must not be empty")
+	}
+	identity, err := age.ParseX25519Identity(r.Keys[r.Active])
+	if err != nil {
+		return "", ErrUnavailable
+	}
+	raw, _ := json.Marshal(payload{Binding: binding, Value: value})
+	var encrypted bytes.Buffer
+	writer, err := age.Encrypt(&encrypted, identity.Recipient())
+	if err != nil {
+		return "", ErrUnavailable
+	}
+	if _, err = writer.Write(raw); err != nil {
+		return "", ErrUnavailable
+	}
+	if writer.Close() != nil {
+		return "", ErrUnavailable
+	}
+	data, _ := json.Marshal(envelope{Version: 1, Key: r.Active, Data: base64.StdEncoding.EncodeToString(encrypted.Bytes())})
+	return string(data), nil
+}
+func CipherKey(ciphertext string) (string, error) {
+	var e envelope
+	if json.Unmarshal([]byte(ciphertext), &e) != nil || e.Version != 1 || e.Key == "" || e.Data == "" {
+		return "", ErrInvalid
+	}
+	return e.Key, nil
+}
+func (r Ring) Decrypt(binding, ciphertext string) (string, error) {
+	id, err := CipherKey(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	identity, err := age.ParseX25519Identity(r.Keys[id])
+	if err != nil {
+		return "", ErrUnavailable
+	}
+	var e envelope
+	_ = json.Unmarshal([]byte(ciphertext), &e)
+	data, err := base64.StdEncoding.DecodeString(e.Data)
+	if err != nil {
+		return "", ErrInvalid
+	}
+	reader, err := age.Decrypt(bytes.NewReader(data), identity)
+	if err != nil {
+		return "", ErrInvalid
+	}
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return "", ErrInvalid
+	}
+	var value payload
+	if json.Unmarshal(raw, &value) != nil || value.Binding != binding || value.Value == "" {
+		return "", ErrInvalid
+	}
+	return value.Value, nil
+}

--- a/internal/recordsecret/recordsecret.go
+++ b/internal/recordsecret/recordsecret.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 
 	"filippo.io/age"
 	"github.com/hapyco/dygo/internal/secrets"
@@ -35,6 +36,12 @@ type payload struct {
 	Value   string `json:"value"`
 }
 type contextKey struct{}
+type operationKey struct{}
+type operationCache struct {
+	once sync.Once
+	ring Ring
+	err  error
+}
 type Provider func() (Ring, error)
 
 func WithProvider(ctx context.Context, provider Provider) context.Context {
@@ -43,10 +50,28 @@ func WithProvider(ctx context.Context, provider Provider) context.Context {
 func WithStore(ctx context.Context, store secrets.Store, env secrets.Environment) context.Context {
 	return WithProvider(ctx, func() (Ring, error) { return Load(store, env) })
 }
+
+// WithOperation creates a per-request or per-mutation key cache. The provider
+// still resolves the encrypted credential store at each operation boundary, so
+// a key rotation is observed by the next operation without rereading it for
+// every secret field in one mutation.
+func WithOperation(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(operationKey{}).(*operationCache); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, operationKey{}, &operationCache{})
+}
+
 func FromContext(ctx context.Context) (Ring, error) {
 	p, ok := ctx.Value(contextKey{}).(Provider)
 	if !ok {
 		return Ring{}, ErrUnavailable
+	}
+	if cache, ok := ctx.Value(operationKey{}).(*operationCache); ok {
+		cache.once.Do(func() {
+			cache.ring, cache.err = p()
+		})
+		return cache.ring, cache.err
 	}
 	return p()
 }

--- a/internal/recordsecret/recordsecret_test.go
+++ b/internal/recordsecret/recordsecret_test.go
@@ -97,3 +97,36 @@ func TestMissingAndCorruptKeysFailClosed(t *testing.T) {
 		t.Fatal("corrupt keys overwritten or leaked")
 	}
 }
+
+func TestOperationCachesProviderResolution(t *testing.T) {
+	calls := 0
+	ctx := WithProvider(context.Background(), func() (Ring, error) {
+		calls++
+		return Ring{Active: "cached", Keys: map[string]string{"cached": ""}}, nil
+	})
+	ctx = WithOperation(ctx)
+	if _, err := FromContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FromContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("provider calls = %d, want one per operation", calls)
+	}
+	if _, err := FromContext(WithOperation(ctx)); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("nested operation reused provider unexpectedly: %d calls", calls)
+	}
+	if _, err := FromContext(WithOperation(WithProvider(context.Background(), func() (Ring, error) {
+		calls++
+		return Ring{}, nil
+	}))); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("new operation calls = %d, want two total", calls)
+	}
+}

--- a/internal/recordsecret/recordsecret_test.go
+++ b/internal/recordsecret/recordsecret_test.go
@@ -1,0 +1,99 @@
+package recordsecret
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/hapyco/dygo/internal/secrets"
+	"strings"
+	"testing"
+)
+
+func testStore(t *testing.T) secrets.Store {
+	t.Helper()
+	s := secrets.NewStore(t.TempDir())
+	if _, err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := Init(s, secrets.EnvironmentDevelopment); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+func TestEncryptionAndKeyLifecycle(t *testing.T) {
+	s := testStore(t)
+	env := secrets.EnvironmentDevelopment
+	r, err := Load(s, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = Init(s, env); err != nil {
+		t.Fatal(err)
+	}
+	same, _ := Load(s, env)
+	if same.Active != r.Active {
+		t.Fatal("init replaced key")
+	}
+	first, err := r.Encrypt("crm/account/token", "sensitive-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _ := r.Encrypt("crm/account/token", "sensitive-value")
+	if first == second || strings.Contains(first, "sensitive-value") {
+		t.Fatal("ciphertext is not randomized and opaque")
+	}
+	value, err := r.Decrypt("crm/account/token", first)
+	if err != nil || value != "sensitive-value" {
+		t.Fatal("round trip failed")
+	}
+	if _, err = r.Decrypt("crm/account/other", first); err == nil {
+		t.Fatal("accepted another field's ciphertext")
+	}
+	for _, raw := range []string{"plaintext", `{"v":2,"key":"x","data":"x"}`, strings.Replace(first, `"data":"`, `"data":"!`, 1)} {
+		if _, err = r.Decrypt("crm/account/token", raw); err == nil {
+			t.Fatal("accepted malformed ciphertext")
+		}
+	}
+	rotated, err := BeginRotation(s, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := BeginRotation(s, env)
+	if err != nil || resumed.Active != rotated.Active || !resumed.Rotating {
+		t.Fatal("rotation did not resume")
+	}
+	if value, err = rotated.Decrypt("crm/account/token", first); err != nil || value != "sensitive-value" {
+		t.Fatal("old backup key lost")
+	}
+	if err = FinishRotation(s, env, rotated); err != nil {
+		t.Fatal(err)
+	}
+	finished, _ := Load(s, env)
+	if finished.Rotating || len(finished.Keys) != 2 {
+		t.Fatal("bad completed key ring")
+	}
+	doc, err := s.Load(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := doc.Values[configKey].(map[string]any); !ok {
+		t.Fatal("key ring must be structured encrypted YAML")
+	}
+	encoded, _ := json.Marshal(doc.Values[configKey])
+	if !strings.Contains(string(encoded), "active") {
+		t.Fatal("missing key data")
+	}
+}
+func TestMissingAndCorruptKeysFailClosed(t *testing.T) {
+	if _, err := FromContext(context.Background()); err == nil {
+		t.Fatal("missing provider accepted")
+	}
+	s := testStore(t)
+	doc, _ := s.Load(secrets.EnvironmentDevelopment)
+	doc.Values[configKey] = map[string]any{"active": "bad", "keys": map[string]any{"bad": "private-invalid-value"}}
+	if err := s.Save(secrets.EnvironmentDevelopment, doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := Init(s, secrets.EnvironmentDevelopment); err == nil || strings.Contains(err.Error(), "private-invalid-value") {
+		t.Fatal("corrupt keys overwritten or leaked")
+	}
+}

--- a/internal/server/record_secrets.go
+++ b/internal/server/record_secrets.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"context"
+	"github.com/go-chi/chi/v5"
+	"github.com/hapyco/dygo/internal/permissions"
+	"github.com/hapyco/dygo/pkg/dygo"
+	"net/http"
+)
+
+func (h recordHandler) secretStatus(w http.ResponseWriter, r *http.Request) {
+	if h.requireStore(w) {
+		return
+	}
+	entity := chi.URLParam(r, "entity")
+	id, err := recordIDParam(entity, chi.URLParam(r, "id"))
+	if err != nil {
+		writeRecordError(w, err)
+		return
+	}
+	if !h.authorize(w, r, entity, permissions.ActionRead, id) {
+		return
+	}
+	store, err := h.storeFor(r, entity, permissions.ActionRead)
+	if err != nil {
+		writePermissionError(w, err)
+		return
+	}
+	statusStore, ok := store.(interface {
+		SecretStatus(context.Context, string, int64) (dygo.SecretStatus, error)
+	})
+	if !ok {
+		writeErrorEnvelope(w, http.StatusServiceUnavailable, "unavailable", "secret status is unavailable", nil)
+		return
+	}
+	status, err := statusStore.SecretStatus(r.Context(), entity, id)
+	if err != nil {
+		writeRecordError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, dataEnvelope{Data: status})
+}

--- a/internal/server/record_secrets_test.go
+++ b/internal/server/record_secrets_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"github.com/hapyco/dygo/internal/permissions"
+	"github.com/hapyco/dygo/pkg/dygo"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type secretStatusStore struct {
+	*fakeRecordStore
+	calls int
+}
+
+func (s *secretStatusStore) SecretStatus(context.Context, string, int64) (dygo.SecretStatus, error) {
+	s.calls++
+	return dygo.SecretStatus{Fields: map[string]bool{"token": true}}, nil
+}
+func TestSecretStatusRouteRequiresPermission(t *testing.T) {
+	for _, denied := range []bool{false, true} {
+		store := &secretStatusStore{fakeRecordStore: &fakeRecordStore{}}
+		checker := &fakePermissionChecker{}
+		if denied {
+			checker.err = permissions.Error{Code: permissions.ErrorDenied, Message: "permission denied"}
+		}
+		response := httptest.NewRecorder()
+		NewRouter(Options{Auth: validFakeAuthStore(), Records: store, Permissions: checker}).ServeHTTP(response, authenticatedRequest(http.MethodGet, "/api/v1/records/user/1/secret-status", ""))
+		if denied {
+			if response.Code != http.StatusForbidden || store.calls != 0 {
+				t.Fatal("status accessed without permission")
+			}
+		} else if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"token":true`) {
+			t.Fatalf("status response: %s", response.Body.String())
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hapyco/dygo/internal/notifications"
 	"github.com/hapyco/dygo/internal/permissions"
 	"github.com/hapyco/dygo/internal/recordquery"
+	"github.com/hapyco/dygo/internal/recordsecret"
 	"github.com/hapyco/dygo/internal/reserved"
 	"github.com/hapyco/dygo/pkg/dygo"
 )
@@ -960,6 +961,11 @@ type recordEntityMetaContextKey struct{}
 func registerRecordRoutes(router chi.Router, store RecordStore, activity ActivityStore, metadata MetadataStore, checker PermissionChecker, actions EntityActionExecutor) {
 	handler := recordHandler{store: store, activity: activity, metadata: metadata, permissions: checker, actions: actions}
 	router.Route("/records/{entity}", func(records chi.Router) {
+		records.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r.WithContext(recordsecret.WithOperation(r.Context())))
+			})
+		})
 		records.Use(handler.resolveEntity)
 		records.Get("/", handler.listRecords)
 		records.Get("/export", handler.exportRecords)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -253,7 +253,8 @@ func ServeListener(ctx context.Context, listener net.Listener, options ...Option
 	}
 
 	httpServer := &http.Server{
-		Handler: NewRouter(opts),
+		Handler:     NewRouter(opts),
+		BaseContext: func(net.Listener) context.Context { return ctx },
 	}
 
 	done := make(chan error, 1)
@@ -964,6 +965,7 @@ func registerRecordRoutes(router chi.Router, store RecordStore, activity Activit
 		records.Get("/export", handler.exportRecords)
 		records.Post("/", handler.createRecord)
 		records.Post("/actions/{action}", handler.executeAction)
+		records.Get("/{id}/secret-status", handler.secretStatus)
 		records.Get("/{id}/activity", handler.listRecordActivity)
 		records.Post("/{id}/activity", handler.addRecordComment)
 		records.Get("/name/{name}", handler.getRecordByName)

--- a/pkg/dygo/hooks.go
+++ b/pkg/dygo/hooks.go
@@ -88,6 +88,8 @@ type RecordListResult struct {
 // RecordData gives hooks transactional access to metadata-backed Records by app/entity identity.
 // Writes run dygo framework hooks, such as Activity, but do not re-enter app hooks.
 type RecordData interface {
+	DecryptSecret(ctx context.Context, appName string, entity string, recordID int64, field string) (string, error)
+	SecretStatus(ctx context.Context, appName string, entity string, recordID int64) (SecretStatus, error)
 	List(ctx context.Context, appName string, entity string, params RecordListParams) (RecordListResult, error)
 	Count(ctx context.Context, appName string, entity string, params RecordListParams) (int64, error)
 	Exists(ctx context.Context, appName string, entity string, params RecordListParams) (bool, error)

--- a/pkg/dygo/records.go
+++ b/pkg/dygo/records.go
@@ -1,6 +1,9 @@
 package dygo
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // AggregateFunction identifies a supported Record aggregate.
 type AggregateFunction string
@@ -53,3 +56,12 @@ type GroupByResult struct {
 
 // RecordTransactionFunc runs app code inside one Record transaction.
 type RecordTransactionFunc func(context.Context, RecordData) error
+
+// ErrSecretUnset reports a secret field with no saved value.
+var ErrSecretUnset = errors.New("secret is not set")
+
+// SecretStatus contains presence only; collection keys are parent field names and row IDs.
+type SecretStatus struct {
+	Fields      map[string]bool                      `json:"fields"`
+	Collections map[string]map[int64]map[string]bool `json:"collections,omitempty"`
+}

--- a/schemas/entity.schema.json
+++ b/schemas/entity.schema.json
@@ -59,6 +59,7 @@
         "email",
         "phone",
         "password",
+        "secret",
         "long-text",
         "int",
         "bigint",


### PR DESCRIPTION
Adds a `secret` Entity field for decryptable integration credentials. Record writes store age ciphertext; generic reads and Hook inputs omit the value. Password hashing is unchanged.

Record keys use the existing encrypted environment YAML and current master key. The SDK requires explicit `AsSystem(reason)` access and records decryption access without values. Studio shows presence and supports masked replacement or explicit clearing. Offline key rotation commits resumable batches and retains old keys for backup recovery.

Validation:
- Full Go suite passed with isolated PostgreSQL regressions enabled.
- Secret regressions cover SDK denial and auditing, parent/Single/collection storage, rollback, Hook sanitization, presence permissions, missing/corrupt keys, and interrupted rotation.
- All 58 Studio tests passed; type checking and embedded Studio build passed.
- Browser preview verified replacement, empty-input preservation, clearing, and required-field controls.

Operations: initialize the Record key before writing secret fields. Stop servers and workers before rotation; `--offline` confirms this operator step. SDK access audit writes follow the supplied Log writer or current transaction. No deployment or existing data conversion is included.

Closes #65
