### PR TITLE
refactor: reduce duplicated framework plumbing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENT.md
+# AGENTS.md
 
 This file gives coding agents the product and engineering context needed to work on dygo.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,6 @@ dygo is an open source framework, but external contributions are not accepted ye
 
 The project is still in early framework development. Core concepts, metadata formats, CLI behavior, app structure, and runtime boundaries are still changing quickly. Until that foundation settles, dygo is maintainer-led so the architecture can stay coherent.
 
-## Current Status
-
-Code contributions are paused.
-
-Please do not open pull requests for features, refactors, documentation rewrites, or bug fixes yet. They are likely to be closed without review while the framework is still taking shape.
-
 ## What Helps Right Now
 
 The most useful support at this stage is reading the public docs and roadmap to understand the direction.
@@ -33,18 +27,5 @@ If you are following the project, start here:
 - [Documentation Index](docs/index.md)
 - [Security Policy](SECURITY.md)
 - [Roadmap](https://github.com/orgs/hapyco/projects/3/views/1)
-
-## When Contributions Reopen
-
-Contribution guidelines will be expanded after dygo moves out of early framework development.
-
-At that point this file should define:
-
-- how to set up a local development environment
-- how to pick up issues from the roadmap
-- coding and testing expectations
-- documentation expectations
-- review and merge rules
-- security reporting guidance
 
 Until then, the repository remains public for transparency, learning, and tracking the framework direction.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/go-1.26.2-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-O%27Saasy-blue)](LICENSE)
-[![Status](https://img.shields.io/badge/status-early%20framework%20development-f2cc60)](https://github.com/hapyco/dygo/commits/develop)
+[![Status](https://img.shields.io/badge/status-early%20framework%20development-f2cc60)](https://github.com/hapyco/dygo/commits/main)
 [![Contributions](https://img.shields.io/badge/contributions-paused-lightgrey)](CONTRIBUTING.md)
 [![Issues](https://img.shields.io/badge/issues-GitHub-2ea44f)](https://github.com/hapyco/dygo/issues)
 
@@ -69,21 +69,7 @@ See [CLI](docs/cli.md) for the full command surface.
 
 ## Documentation
 
-- [Documentation Index](docs/index.md)
-- [Installation](docs/installation.md)
-- [CLI](docs/cli.md)
-- [App Model](docs/app-model.md)
-- [Entity Metadata](docs/entity-metadata.md)
-- [Database](docs/database.md)
-- [Records](docs/records.md)
-- [Record Hooks](docs/record-hooks.md)
-- [Jobs](docs/jobs.md)
-- [Queues And Workers](docs/queues.md)
-- [Schedules](docs/schedule.md)
-- [Server](docs/server.md)
-- [Studio](docs/studio.md)
-- [App SDK](docs/sdk.md)
-- [Encrypted Secrets](docs/secrets.md)
+See the [Documentation Index](docs/index.md) for the full reference.
 
 ## Repository Development
 

--- a/apps/studio/ui/src/features/dialogs/DialogHost.vue
+++ b/apps/studio/ui/src/features/dialogs/DialogHost.vue
@@ -10,7 +10,7 @@ import {
 } from 'reka-ui'
 
 import { Button } from '@/design'
-import { useDialogStore, type StudioDialog, type StudioDialogActionVariant } from './dialogs.store'
+import { useDialogStore, type StudioDialog } from './dialogs.store'
 
 const dialogStore = useDialogStore()
 const topDialog = computed(() => dialogStore.topDialog)
@@ -35,9 +35,6 @@ function choose(dialog: StudioDialog, key: string) {
   dialogStore.selectAction(dialog.id, key)
 }
 
-function buttonVariant(variant: StudioDialogActionVariant): 'primary' | 'secondary' | 'danger' {
-  return variant === 'danger' ? 'danger' : variant
-}
 </script>
 
 <template>
@@ -61,7 +58,7 @@ function buttonVariant(variant: StudioDialogActionVariant): 'primary' | 'seconda
           <Button
             v-for="action in topDialog.actions"
             :key="action.key"
-            :variant="buttonVariant(action.variant)"
+            :variant="action.variant"
             size="sm"
             @click="choose(topDialog, action.key)"
           >

--- a/apps/studio/ui/src/features/metadata/metadata.query.ts
+++ b/apps/studio/ui/src/features/metadata/metadata.query.ts
@@ -28,7 +28,7 @@ export function metadataEntityMetaQueryOptions(entity: string) {
 export function useMetadataEntitiesQuery(options: { enabled?: QueryToggle } = {}) {
   return useQuery({
     ...metadataEntitiesQueryOptions(),
-    enabled: queryEnabled(options.enabled),
+    enabled: computed(() => toValue(options.enabled ?? true)),
   })
 }
 
@@ -40,8 +40,4 @@ export function useMetadataEntityMetaQuery(entity: MaybeRefOrGetter<string>, opt
     queryFn: ({ signal }) => getEntityMeta(currentEntity.value, { signal }),
     enabled: computed(() => currentEntity.value !== '' && toValue(options.enabled ?? true)),
   })
-}
-
-function queryEnabled(enabled: QueryToggle | undefined) {
-  return computed(() => toValue(enabled ?? true))
 }

--- a/apps/studio/ui/src/features/records/records.api.ts
+++ b/apps/studio/ui/src/features/records/records.api.ts
@@ -53,15 +53,7 @@ export type ImportInfo = {
 }
 export type FileInfo = { id: number, filename: string }
 
-type ListRecordsOptions = {
-  signal?: AbortSignal
-}
-
-type ReadRecordOptions = {
-  signal?: AbortSignal
-}
-
-type ActivityOptions = {
+type RequestOptions = {
   signal?: AbortSignal
 }
 
@@ -71,7 +63,7 @@ export class RecordApiError extends ApiClientError {
   }
 }
 
-export async function listRecords(entity: string, params: ListRecordsParams, options: ListRecordsOptions = {}): Promise<ListEnvelope<RecordData[], RecordListMeta>> {
+export async function listRecords(entity: string, params: ListRecordsParams, options: RequestOptions = {}): Promise<ListEnvelope<RecordData[], RecordListMeta>> {
   const query = buildRecordListQuery(params)
 
   return apiRequest<ListEnvelope<RecordData[], RecordListMeta>, RecordApiError>(`/api/v1/records/${encodeURIComponent(entity)}?${query.toString()}`, {
@@ -115,7 +107,7 @@ export async function uploadRecordFile(app: string, entity: string, recordID: nu
   return payload.data
 }
 
-export async function getRecordByName(entity: string, recordName: string, options: ReadRecordOptions = {}): Promise<RecordData> {
+export async function getRecordByName(entity: string, recordName: string, options: RequestOptions = {}): Promise<RecordData> {
   const payload = await apiRequest<DataEnvelope<RecordData>, RecordApiError>(`/api/v1/records/${encodeURIComponent(entity)}/name/${encodeURIComponent(recordName)}`, {
     method: 'GET',
     signal: options.signal,
@@ -124,7 +116,7 @@ export async function getRecordByName(entity: string, recordName: string, option
   return payload.data
 }
 
-export async function getSingleRecord(entity: string, options: ReadRecordOptions = {}): Promise<RecordData> {
+export async function getSingleRecord(entity: string, options: RequestOptions = {}): Promise<RecordData> {
   const payload = await apiRequest<DataEnvelope<RecordData>, RecordApiError>(`/api/v1/records/${encodeURIComponent(entity)}/single`, {
     method: 'GET',
     signal: options.signal,
@@ -169,7 +161,7 @@ export async function updateSingleRecord(entity: string, data: RecordData): Prom
   return payload.data
 }
 
-export async function listRecordActivity(entity: string, id: string | number, options: ActivityOptions = {}): Promise<ListEnvelope<ActivityEntry[], ActivityListMeta>> {
+export async function listRecordActivity(entity: string, id: string | number, options: RequestOptions = {}): Promise<ListEnvelope<ActivityEntry[], ActivityListMeta>> {
   const query = new URLSearchParams({ limit: '50', offset: '0' })
   return apiRequest<ListEnvelope<ActivityEntry[], ActivityListMeta>, RecordApiError>(`/api/v1/records/${encodeURIComponent(entity)}/${encodeURIComponent(String(id))}/activity?${query.toString()}`, {
     method: 'GET',

--- a/apps/studio/ui/src/renderers/records/RecordCollectionTable.vue
+++ b/apps/studio/ui/src/renderers/records/RecordCollectionTable.vue
@@ -2,12 +2,13 @@
 import { computed } from 'vue'
 import { ArrowDown, ArrowUp, Plus, Trash2 } from '@lucide/vue'
 
-import { Button, IconButton, Input, Select, Switch, Textarea, type FieldOption, type TextInputType } from '@/design'
+import { Button, IconButton, Input, Select, Switch, Textarea } from '@/design'
 import type { MetadataEntityMeta, MetadataField } from '@/features/metadata/metadata.api'
 import type { RecordData } from '@/features/records/records.api'
 import { isHiddenCollectionField, recordFieldLabel } from '@/features/records/system-fields'
 import SecretEditor from './SecretEditor.vue'
 import LinkPicker from './LinkPicker.vue'
+import { booleanValue, editorForField, inputTypeForField, isTextareaField, isTextField, selectOptions, textValue } from './record-field-utils'
 
 const props = withDefaults(defineProps<{
   id: string
@@ -123,65 +124,6 @@ function fieldId(field: MetadataField, index: number): string {
   return `${props.id}-${index}-${field.name}`.replace(/[^a-zA-Z0-9_-]+/g, '-')
 }
 
-function textValue(row: RecordData, field: MetadataField): string {
-  const value = row[field.name]
-  if (value === null || value === undefined) {
-    return ''
-  }
-  if (typeof value === 'string') {
-    return value
-  }
-  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
-    return String(value)
-  }
-  return JSON.stringify(value, null, 2)
-}
-
-function booleanValue(row: RecordData, field: MetadataField): boolean {
-  return row[field.name] === true
-}
-
-function inputTypeForField(field: MetadataField): Exclude<TextInputType, 'password'> {
-  switch (editorForField(field)) {
-    case 'email':
-      return 'email'
-    case 'date':
-      return 'date'
-    case 'number':
-      return 'number'
-    default:
-      return 'text'
-  }
-}
-
-function editorForField(field: MetadataField): string {
-  return field.studio?.editor || field.type
-}
-
-function isTextField(field: MetadataField): boolean {
-  return ['text', 'email', 'number', 'link', 'date', 'datetime', 'time', 'password'].includes(editorForField(field))
-}
-
-function isTextareaField(field: MetadataField): boolean {
-  return editorForField(field) === 'textarea' || editorForField(field) === 'json'
-}
-
-function selectOptions(field: MetadataField): FieldOption[] {
-  const options = field.options
-  if (!options || typeof options !== 'object' || !('values' in options)) {
-    return []
-  }
-
-  const values = (options as { values?: unknown }).values
-  if (!Array.isArray(values)) {
-    return []
-  }
-
-  return values
-    .filter((value): value is string | number => typeof value === 'string' || typeof value === 'number')
-    .map((value) => ({ value: String(value), label: String(value) }))
-}
-
 </script>
 
 <template>
@@ -212,7 +154,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
                 :id="fieldId(column, rowIndex)"
                 :label="recordFieldLabel(column)"
                 :field="column"
-                :model-value="textValue(row, column)"
+                :model-value="textValue(row[column.name])"
                 :current-values="row"
                 :required="column.required"
                 :disabled="disabled"
@@ -224,7 +166,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
               <Select
                 v-else-if="editorForField(column) === 'select'"
                 :id="fieldId(column, rowIndex)"
-                :model-value="textValue(row, column)"
+                :model-value="textValue(row[column.name])"
                 :name="`${field.name}.${rowIndex}.${column.name}`"
                 :options="selectOptions(column)"
                 size="sm"
@@ -236,7 +178,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
               <Switch
                 v-else-if="editorForField(column) === 'switch'"
                 :id="fieldId(column, rowIndex)"
-                :model-value="booleanValue(row, column)"
+                :model-value="booleanValue(row[column.name])"
                 :name="`${field.name}.${rowIndex}.${column.name}`"
                 :disabled="disabled"
                 :invalid="Boolean(error)"
@@ -246,7 +188,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
               <Textarea
                 v-else-if="isTextareaField(column)"
                 :id="fieldId(column, rowIndex)"
-                :model-value="textValue(row, column)"
+                :model-value="textValue(row[column.name])"
                 :name="`${field.name}.${rowIndex}.${column.name}`"
                 size="xs"
                 :rows="2"
@@ -268,7 +210,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
               <Input
                 v-else-if="isTextField(column)"
                 :id="fieldId(column, rowIndex)"
-                :model-value="textValue(row, column)"
+                :model-value="textValue(row[column.name])"
                 :name="`${field.name}.${rowIndex}.${column.name}`"
                 :type="editorForField(column) === 'password' ? 'password' : inputTypeForField(column)"
                 size="sm"
@@ -280,7 +222,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
               <Input
                 v-else
                 :id="fieldId(column, rowIndex)"
-                :model-value="textValue(row, column)"
+                :model-value="textValue(row[column.name])"
                 :name="`${field.name}.${rowIndex}.${column.name}`"
                 size="sm"
                 readonly

--- a/apps/studio/ui/src/renderers/records/RecordFormRenderer.vue
+++ b/apps/studio/ui/src/renderers/records/RecordFormRenderer.vue
@@ -8,8 +8,6 @@ import {
   SwitchField,
   TextareaField,
   TextField,
-  type FieldOption,
-  type TextInputType,
 } from '@/design'
 import { linkOptions, type MetadataEntityMeta, type MetadataField } from '@/features/metadata/metadata.api'
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
@@ -21,6 +19,7 @@ import RecordCollectionTable from './RecordCollectionTable.vue'
 import LinkPicker from './LinkPicker.vue'
 import AttachmentEditor from './AttachmentEditor.vue'
 import { RouteName } from '@/router/routes'
+import { booleanValue, editorForField, inputTypeForField, isTextareaField, isTextField, selectOptions, textValue } from './record-field-utils'
 
 const props = withDefaults(defineProps<{
   entity: string
@@ -98,67 +97,6 @@ function isReadonlyField(field: MetadataField): boolean {
   return props.mode !== 'new' && field.name === 'name'
 }
 
-function textValue(field: MetadataField): string {
-  const value = props.modelValue[field.name]
-  if (value === null || value === undefined) {
-    return ''
-  }
-
-  if (typeof value === 'string') {
-    return value
-  }
-
-  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
-    return String(value)
-  }
-
-  return JSON.stringify(value, null, 2)
-}
-
-function booleanValue(field: MetadataField): boolean {
-  return props.modelValue[field.name] === true
-}
-
-function inputTypeForField(field: MetadataField): Exclude<TextInputType, 'password'> {
-  switch (editorForField(field)) {
-    case 'email':
-      return 'email'
-    case 'date':
-      return 'date'
-    case 'number':
-      return 'number'
-    default:
-      return 'text'
-  }
-}
-
-function editorForField(field: MetadataField): string {
-  return field.studio?.editor || field.type
-}
-
-function isTextField(field: MetadataField): boolean {
-  return ['text', 'email', 'number', 'link', 'date', 'datetime', 'time'].includes(editorForField(field))
-}
-
-function isTextareaField(field: MetadataField): boolean {
-  return editorForField(field) === 'textarea' || editorForField(field) === 'json'
-}
-
-function selectOptions(field: MetadataField): FieldOption[] {
-  const options = field.options
-  if (!options || typeof options !== 'object' || !('values' in options)) {
-    return []
-  }
-
-  const values = (options as { values?: unknown }).values
-  if (!Array.isArray(values)) {
-    return []
-  }
-
-  return values
-    .filter((value): value is string | number => typeof value === 'string' || typeof value === 'number')
-    .map((value) => ({ value: String(value), label: String(value) }))
-}
 </script>
 
 <template>
@@ -196,7 +134,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else-if="editorForField(field) === 'password'"
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :name="field.name"
         :required="mode === 'new' && field.required"
         :disabled="disabled"
@@ -211,7 +149,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else-if="editorForField(field) === 'switch'"
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="booleanValue(field)"
+        :model-value="booleanValue(modelValue[field.name])"
         :name="field.name"
         :required="field.required"
         :disabled="disabled"
@@ -224,7 +162,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else-if="editorForField(field) === 'select'"
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :name="field.name"
         :options="selectOptions(field)"
         :required="field.required"
@@ -240,7 +178,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
         :field="field"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :current-values="modelValue"
         :required="field.required"
         :disabled="disabled"
@@ -255,7 +193,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else-if="isTextareaField(field)"
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :name="field.name"
         :required="field.required"
         :disabled="disabled"
@@ -269,7 +207,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else-if="isTextField(field)"
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :name="field.name"
         :type="inputTypeForField(field)"
         :required="field.required"
@@ -283,7 +221,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else-if="field.type === 'attachment'"
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :upload="attachmentUpload(field)"
         :disabled="disabled"
         :readonly="isReadonlyField(field)"
@@ -295,7 +233,7 @@ function selectOptions(field: MetadataField): FieldOption[] {
         v-else
         :id="fieldId(field)"
         :label="recordFieldLabel(field)"
-        :model-value="textValue(field)"
+        :model-value="textValue(modelValue[field.name])"
         :name="field.name"
         readonly
         :disabled="disabled"

--- a/apps/studio/ui/src/renderers/records/record-field-utils.ts
+++ b/apps/studio/ui/src/renderers/records/record-field-utils.ts
@@ -1,0 +1,60 @@
+import type { FieldOption, TextInputType } from '@/design'
+import type { MetadataField } from '@/features/metadata/metadata.api'
+
+export function textValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+    return String(value)
+  }
+  return JSON.stringify(value, null, 2)
+}
+
+export function booleanValue(value: unknown): boolean {
+  return value === true
+}
+
+export function inputTypeForField(field: MetadataField): Exclude<TextInputType, 'password'> {
+  switch (editorForField(field)) {
+    case 'email':
+      return 'email'
+    case 'date':
+      return 'date'
+    case 'number':
+      return 'number'
+    default:
+      return 'text'
+  }
+}
+
+export function editorForField(field: MetadataField): string {
+  return field.studio?.editor || field.type
+}
+
+export function isTextField(field: MetadataField): boolean {
+  return ['text', 'email', 'number', 'link', 'date', 'datetime', 'time', 'password'].includes(editorForField(field))
+}
+
+export function isTextareaField(field: MetadataField): boolean {
+  return editorForField(field) === 'textarea' || editorForField(field) === 'json'
+}
+
+export function selectOptions(field: MetadataField): FieldOption[] {
+  const options = field.options
+  if (!options || typeof options !== 'object' || !('values' in options)) {
+    return []
+  }
+
+  const values = (options as { values?: unknown }).values
+  if (!Array.isArray(values)) {
+    return []
+  }
+
+  return values
+    .filter((value): value is string | number => typeof value === 'string' || typeof value === 'number')
+    .map((value) => ({ value: String(value), label: String(value) }))
+}

--- a/apps/studio/ui/src/shell/CommandMenu.vue
+++ b/apps/studio/ui/src/shell/CommandMenu.vue
@@ -217,10 +217,8 @@ onKeyStroke((event) => {
 
 }, { passive: false })
 
-async function openMenu() {
+function openMenu() {
   navigationStore.openCommandMenu()
-  await nextTick()
-  searchInput.value?.focus()
 }
 
 function closeMenu() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,4 +56,4 @@ Use this index to find the right document for the task. The docs are kept in the
 - [Project README](../README.md) gives a short overview and quick start.
 - [Contributing](../CONTRIBUTING.md) explains the current paused contribution status.
 - [Security Policy](../SECURITY.md) explains private vulnerability reporting and safe research guidelines.
-- [Agent Instructions](../AGENT.md) stores repo-level guidance for coding agents.
+- [Agent Instructions](../AGENTS.md) stores repo-level guidance for coding agents.

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -28,7 +28,7 @@ The Core app owns a system Entity with key `log`, label `Log`, and Studio naviga
 
 The Entity should be append-only by default. App code and framework code create Logs; normal app workflows should not edit them.
 
-Proposed fields:
+Fields:
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
@@ -49,36 +49,6 @@ All Log `link` fields should use `foreign-key: false` so old Logs survive target
 Do not use `fetch.from` for `app`. Logs often belong to an app without belonging to a specific Record, and an explicit producer app should not be overwritten by a reference-derived value.
 
 Do not add custom indexes in the first pass. Logs should start with the normal Core Record storage shape, and dygo should add indexes later only after Studio usage shows a repeated access pattern that needs one.
-
-## Field Review
-
-Common loggers and observability tools converge on a small set of concepts:
-
-- level or severity
-- message or body
-- timestamp
-- source, logger, scope, or resource
-- error or exception details
-- trace correlation
-- structured attributes, tags, or context
-- user context for application errors
-
-The proposed Log fields cover those concepts without making the Entity too wide:
-
-| Common concept | dygo field |
-| --- | --- |
-| level or severity | `type` |
-| message or body | `title`, optionally `message` |
-| timestamp | Core Record `created-at` |
-| source, logger, scope, or resource | `source`, optionally `metadata` |
-| error, exception, stack trace, traceback, or longer detail | `message` |
-| trace correlation | `trace-id` |
-| structured attributes, tags, or context | `metadata` |
-| user context | `actor`, optionally `metadata` |
-| producing app | `app` |
-| related object | `reference-entity`, `reference-record-id`, `reference-record-name` |
-
-Do not add dedicated v1 fields for `span-id`, `environment`, `release`, `logger`, `request-path`, `status-code`, `fingerprint`, or breadcrumbs. Put those in `metadata` until dygo has a clear Studio workflow that needs first-class filtering or display.
 
 ## Types
 
@@ -244,12 +214,3 @@ Activity stays focused on human-meaningful Record history.
 Audit Log remains a future compliance/security feature with stricter immutability, access rules, and lifecycle requirements.
 
 Local console logging remains useful while developing, especially before the database is available.
-
-## Implementation Order
-
-Recommended first pass:
-
-1. Add Core `log` Entity metadata.
-2. Add dygo helpers for `Debug`, `Info`, `Warning`, `Error`, and structured `Log`.
-3. Dogfood Logs with recovered panic writers first.
-4. Expose Logs through the generic Record API and Studio list/detail UI.

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -48,17 +48,3 @@ Technical implementation details may still use words such as document when they 
 | Generated print/PDF design | Print Format |
 | Report definition/output | Report |
 | Dashboard/chart area | Dashboard |
-
-## Example Language
-
-The Studio contains Spaces.
-
-A Space organizes work around a business function.
-
-An Entity defines Fields and Record Collections. Apps attach Permissions, Hooks, Fixtures, and Patches around Entities.
-
-A Record is saved data created from an Entity.
-
-A Record Collection contains Rows inside a Record.
-
-The Studio globally renders Entities and Records.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -38,39 +38,6 @@ These are intentionally not part of the current public CLI contract:
 - Studio retry and cancel controls for Job Executions
 - production secret providers such as KMS or Vault
 
-## Reduction Scan
-
-These notes came from a static reduction scan. Re-check each item before deleting or refactoring code.
-
-High-confidence delete candidates:
-
-- `apps/studio/ui/src/design/atoms/Divider.vue`
-- `apps/studio/ui/src/design/molecules/FieldRow.vue`
-- `apps/studio/ui/src/design/molecules/FormSection.vue`
-- `apps/studio/ui/src/design/molecules/SearchBox.vue`
-- `apps/studio/ui/src/design/molecules/RadioGroupField.vue`
-- `apps/studio/ui/src/design/primitives/RadioGroup.vue`
-
-DRY candidates:
-
-- Share fixture dependency sorting between validation and apply.
-- Share nested fixture link decoding between validation and apply.
-- Reduce repeated public identity and layout dispatch in Record CRUD.
-- Table-drive generator command construction.
-- Share field normalization and editor selection across record renderers.
-
-Large files to watch:
-
-- `internal/db/records.go`
-- `internal/db/schema_plan.go`
-- `internal/fixtures/fixtures.go`
-- `internal/cli/db.go`
-- `apps/studio/ui/src/design/organisms/DataTable.vue`
-- `apps/studio/ui/src/pages/RecordFormPage.vue`
-- `apps/studio/ui/src/renderers/records/RecordCollectionTable.vue`
-- `internal/cli/root_test.go`
-- `internal/db/records_test.go`
-
 Naming notes:
 
 - `internal/studio/assets.go` is really Studio bundle source resolution, cache installation, and static handler wiring.

--- a/docs/records.md
+++ b/docs/records.md
@@ -22,9 +22,11 @@ GET    /api/v1/records/{entity}?limit=50&offset=0&status:eq=Open&sort=-created-a
 GET    /api/v1/records/{entity}/{id}
 GET    /api/v1/records/{entity}/name/{name}
 GET    /api/v1/records/{entity}/single
+GET    /api/v1/records/{entity}/export
 GET    /api/v1/records/{entity}/{id}/activity?limit=50&offset=0
 POST   /api/v1/records/{entity}/{id}/activity
 POST   /api/v1/records/{entity}
+POST   /api/v1/records/{entity}/actions/{action}
 PATCH  /api/v1/records/{entity}/{id}
 PATCH  /api/v1/records/{entity}/single
 DELETE /api/v1/records/{entity}/{id}
@@ -183,7 +185,7 @@ The endpoint returns newest-first Activity ordered by `created-at DESC, id DESC`
 {"data":[],"meta":{"limit":50,"offset":0,"count":0}}
 ```
 
-Activity lookup uses the target Entity and Record ID, so history can still be read after the live Record row has been deleted. It requires authentication and `read` permission on the target Entity with the target Record ID. It does not require generic `activity` Entity permission.
+Activity lookup requires the live target Record, authentication, and `read` permission on the target Entity with the target Record ID. It does not require generic `activity` Entity permission.
 
 Activity items include `id`, `created-at`, `entity`, `record-id`, `kind`, `operation`, `status`, `title`, `message`, `actor`, `changes`, `snapshot`, and `details`. `actor` is `null` when no user caused the change, otherwise it contains `id`, `email`, and `full-name`.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -20,7 +20,6 @@ Source: local staging list for `hapyco/dygo`, last updated on 2026-05-31.
 - [ ] #261 Make reserved names and fixture eligibility policies extendable by apps
 - [ ] #262 Design versioned metadata import and replacement behavior for duplicate authored Records
 - [ ] #33 Add site command group
-- [x] #38 Add one-command local project setup
 - [ ] #51 Add Studio metadata browser
 - [ ] #65 Add secret field type
 - [ ] #68 Add account invitations and password recovery

--- a/internal/cli/access.go
+++ b/internal/cli/access.go
@@ -14,14 +14,7 @@ import (
 )
 
 func newAccessCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, runner accessRunner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "access",
-		Short: "Manage app access metadata",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("access", "Manage app access metadata")
 
 	cmd.AddCommand(newAccessValidateCommand(ctx, stdout, runner))
 	cmd.AddCommand(newAccessApplyCommand(ctx, stdin, stdout, stderr, runner))

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -11,14 +11,7 @@ import (
 )
 
 func newAppCommand(stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "app",
-		Short: "Manage dygo apps",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("app", "Manage dygo apps")
 
 	cmd.AddCommand(newAppsListCommand(stdout))
 	cmd.AddCommand(newAppsValidateCommand(stdout))

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -13,14 +13,7 @@ import (
 )
 
 func newDBCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, database databaseRunner, sync schemaSyncRunner, fixture fixtureRunner, accessRunner accessRunner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "db",
-		Short: "Manage dygo database lifecycle",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("db", "Manage dygo database lifecycle")
 
 	cmd.AddCommand(newDBCheckCommand(ctx, stdout, database))
 	cmd.AddCommand(newDBCreateCommand(ctx, stdout, database))
@@ -563,8 +556,47 @@ func applyDBPreparation(ctx context.Context, sync schemaSyncRunner, fixture fixt
 }
 
 func writeDBMigratePlan(stdout io.Writer, env secrets.Environment, plan dbMigrationPlan) error {
+	return writeDBSchemaPlan(stdout, env, "db migrate plan", plan)
+}
+
+func writeDBMigrateResult(stdout io.Writer, env secrets.Environment, result dbMigrationResult) error {
+	return writeDBMigrationResult(stdout, env, "database migrated", result)
+}
+
+func writeDBPrepareHeader(stdout io.Writer, env secrets.Environment, status db.DatabaseStatus) error {
+	state := "exists"
+	if !status.Exists {
+		state = "missing"
+	}
+	_, err := fmt.Fprintf(stdout, "database %s: %s (%s)\n", state, status.Name, env)
+	return err
+}
+
+func writeDBPreparePlan(stdout io.Writer, env secrets.Environment, plan dbPreparationPlan) error {
+	if err := writeDBSchemaPlan(stdout, env, "db prepare plan", plan.Migration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "access: %d roles, %d policy files, %d permissions\n", plan.Access.Roles, plan.Access.Policies, plan.Access.Permissions); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(stdout, "fixtures: %d files, %d records\n", plan.Fixtures.FileCount(), plan.Fixtures.RecordCount())
+	return err
+}
+
+func writeDBPrepareResult(stdout io.Writer, env secrets.Environment, result dbPreparationResult) error {
+	if err := writeDBMigrationResult(stdout, env, "database prepared", result.Migration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "access records: %d roles, %d permissions\n", result.Access.Roles, result.Access.Permissions); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(stdout, "fixture records: %d created, %d updated\n", result.Fixtures.Created, result.Fixtures.Updated)
+	return err
+}
+
+func writeDBSchemaPlan(stdout io.Writer, env secrets.Environment, title string, plan dbMigrationPlan) error {
 	unsafeCount, unsupportedCount := schemaDiagnosticCounts(plan.Schema)
-	if _, err := fmt.Fprintf(stdout, "db migrate plan (%s)\n", env); err != nil {
+	if _, err := fmt.Fprintf(stdout, "%s (%s)\n", title, env); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(stdout, "pre-sync patches: %d pending, %d applied\n", len(plan.PreSync.Pending), len(plan.PreSync.Applied)); err != nil {
@@ -579,14 +611,12 @@ func writeDBMigratePlan(stdout io.Writer, env secrets.Environment, plan dbMigrat
 	if _, err := fmt.Fprintf(stdout, "schema unsupported diagnostics: %d\n", unsupportedCount); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(stdout, "post-sync patches: %d pending, %d applied\n", len(plan.PostSync.Pending), len(plan.PostSync.Applied)); err != nil {
-		return err
-	}
-	return nil
+	_, err := fmt.Fprintf(stdout, "post-sync patches: %d pending, %d applied\n", len(plan.PostSync.Pending), len(plan.PostSync.Applied))
+	return err
 }
 
-func writeDBMigrateResult(stdout io.Writer, env secrets.Environment, result dbMigrationResult) error {
-	if _, err := fmt.Fprintf(stdout, "database migrated (%s)\n", env); err != nil {
+func writeDBMigrationResult(stdout io.Writer, env secrets.Environment, title string, result dbMigrationResult) error {
+	if _, err := fmt.Fprintf(stdout, "%s (%s)\n", title, env); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(stdout, "pre-sync patches applied: %d\n", len(result.PreSync.Applied)); err != nil {
@@ -599,65 +629,6 @@ func writeDBMigrateResult(stdout io.Writer, env secrets.Environment, result dbMi
 		return err
 	}
 	_, err := fmt.Fprintln(stdout, "schema snapshot: refreshed")
-	return err
-}
-
-func writeDBPrepareHeader(stdout io.Writer, env secrets.Environment, status db.DatabaseStatus) error {
-	state := "exists"
-	if !status.Exists {
-		state = "missing"
-	}
-	_, err := fmt.Fprintf(stdout, "database %s: %s (%s)\n", state, status.Name, env)
-	return err
-}
-
-func writeDBPreparePlan(stdout io.Writer, env secrets.Environment, plan dbPreparationPlan) error {
-	unsafeCount, unsupportedCount := schemaDiagnosticCounts(plan.Migration.Schema)
-	if _, err := fmt.Fprintf(stdout, "db prepare plan (%s)\n", env); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "pre-sync patches: %d pending, %d applied\n", len(plan.Migration.PreSync.Pending), len(plan.Migration.PreSync.Applied)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "schema safe operations: %d\n", len(plan.Migration.Schema.Operations)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "schema unsafe diagnostics: %d\n", unsafeCount); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "schema unsupported diagnostics: %d\n", unsupportedCount); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "post-sync patches: %d pending, %d applied\n", len(plan.Migration.PostSync.Pending), len(plan.Migration.PostSync.Applied)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "access: %d roles, %d policy files, %d permissions\n", plan.Access.Roles, plan.Access.Policies, plan.Access.Permissions); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(stdout, "fixtures: %d files, %d records\n", plan.Fixtures.FileCount(), plan.Fixtures.RecordCount())
-	return err
-}
-
-func writeDBPrepareResult(stdout io.Writer, env secrets.Environment, result dbPreparationResult) error {
-	if _, err := fmt.Fprintf(stdout, "database prepared (%s)\n", env); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "pre-sync patches applied: %d\n", len(result.Migration.PreSync.Applied)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(stdout, migrateResultLine(result.Migration.Schema, env)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "post-sync patches applied: %d\n", len(result.Migration.PostSync.Applied)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(stdout, "schema snapshot: refreshed"); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "access records: %d roles, %d permissions\n", result.Access.Roles, result.Access.Permissions); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(stdout, "fixture records: %d created, %d updated\n", result.Fixtures.Created, result.Fixtures.Updated)
 	return err
 }
 

--- a/internal/cli/entities.go
+++ b/internal/cli/entities.go
@@ -21,14 +21,7 @@ type entityRelation struct {
 }
 
 func newEntityCommand(stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "entity",
-		Short: "Manage dygo entities",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("entity", "Manage dygo entities")
 
 	cmd.AddCommand(newEntitiesListCommand(stdout))
 	cmd.AddCommand(newEntitiesValidateCommand(stdout))

--- a/internal/cli/fixtures.go
+++ b/internal/cli/fixtures.go
@@ -12,14 +12,7 @@ import (
 )
 
 func newFixtureCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, runner fixtureRunner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "fixture",
-		Short: "Manage app-owned fixture records",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("fixture", "Manage app-owned fixture records")
 
 	cmd.AddCommand(newFixtureApplyCommand(ctx, stdin, stdout, stderr, runner))
 	cmd.AddCommand(newFixtureExportCommand(ctx, stdin, stdout, stderr, runner))

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -13,15 +13,7 @@ import (
 )
 
 func newGenerateCommand(stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "generate",
-		Aliases: []string{"g"},
-		Short:   "Generate dygo source scaffolding",
-		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("generate", "Generate dygo source scaffolding", "g")
 
 	cmd.AddCommand(newGenerateAppCommand(stdout))
 	cmd.AddCommand(newGenerateEntityCommand(stdout))

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -13,14 +13,7 @@ import (
 )
 
 func newHookCommand(stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "hook",
-		Short: "Inspect and maintain dygo hooks",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("hook", "Inspect and maintain dygo hooks")
 
 	cmd.AddCommand(newHookListCommand(stdout))
 	cmd.AddCommand(newHookValidateCommand(stdout))

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -35,6 +35,11 @@ type jobExecutionStore interface {
 	Retry(context.Context, string, string) (jobstore.Execution, error)
 }
 
+type labeledJobValue struct {
+	label string
+	value string
+}
+
 var openJobExecutionStore = func(ctx context.Context, databaseURL string, queueConfig ...queues.Config) (jobExecutionStore, func(), error) {
 	pool, err := pgxpool.New(ctx, databaseURL)
 	if err != nil {
@@ -49,14 +54,7 @@ var openJobExecutionStore = func(ctx context.Context, databaseURL string, queueC
 }
 
 func newJobCommand(ctx context.Context, stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "job",
-		Short: "Manage dygo Jobs",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("job", "Manage dygo Jobs")
 
 	cmd.AddCommand(newJobListCommand(ctx, stdout))
 	cmd.AddCommand(newJobShowCommand(ctx, stdout))
@@ -195,15 +193,7 @@ func newJobEnableCommand(ctx context.Context, stdout io.Writer) *cobra.Command {
 }
 
 func newJobExecutionCommand(ctx context.Context, stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "execution",
-		Aliases: []string{"exec"},
-		Short:   "Manage Job Executions",
-		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("execution", "Manage Job Executions", "exec")
 
 	cmd.AddCommand(newJobExecutionRunCommand(ctx, stdout))
 	cmd.AddCommand(newJobExecutionListCommand(ctx, stdout))
@@ -431,10 +421,7 @@ func writeJobList(stdout io.Writer, jobs []jobstore.Job) error {
 }
 
 func writeJobShow(stdout io.Writer, job jobstore.Job) error {
-	lines := []struct {
-		label string
-		value string
-	}{
+	lines := []labeledJobValue{
 		{"id", strconv.FormatInt(job.ID, 10)},
 		{"name", emptyDash(job.Name)},
 		{"app", emptyDash(job.AppName)},
@@ -449,12 +436,7 @@ func writeJobShow(stdout io.Writer, job jobstore.Job) error {
 		{"timeout", emptyDash(job.Timeout)},
 		{"retry", formatJobExecutionRetry(job.Retry)},
 	}
-	for _, line := range lines {
-		if _, err := fmt.Fprintf(stdout, "%s: %s\n", line.label, line.value); err != nil {
-			return fmt.Errorf("write job show output: %w", err)
-		}
-	}
-	return nil
+	return writeLabeledJobValues(stdout, "job show", lines)
 }
 
 func writeJobExecutionList(stdout io.Writer, executions []jobstore.Execution) error {
@@ -485,10 +467,7 @@ func writeJobExecutionList(stdout io.Writer, executions []jobstore.Execution) er
 }
 
 func writeJobExecutionShow(stdout io.Writer, execution jobstore.Execution) error {
-	lines := []struct {
-		label string
-		value string
-	}{
+	lines := []labeledJobValue{
 		{"id", strconv.FormatInt(execution.ID, 10)},
 		{"name", emptyDash(execution.Name)},
 		{"job", execution.AppName + "/" + execution.JobName},
@@ -508,9 +487,13 @@ func writeJobExecutionShow(stdout io.Writer, execution jobstore.Execution) error
 		{"result", formatJobExecutionJSON(execution.Result)},
 		{"error", emptyDash(execution.Error)},
 	}
+	return writeLabeledJobValues(stdout, "job execution show", lines)
+}
+
+func writeLabeledJobValues(stdout io.Writer, context string, lines []labeledJobValue) error {
 	for _, line := range lines {
 		if _, err := fmt.Fprintf(stdout, "%s: %s\n", line.label, line.value); err != nil {
-			return fmt.Errorf("write job execution show output: %w", err)
+			return fmt.Errorf("write %s output: %w", context, err)
 		}
 	}
 	return nil
@@ -518,10 +501,7 @@ func writeJobExecutionShow(stdout io.Writer, execution jobstore.Execution) error
 
 func parseJobExecutionRunPayload(value string) (json.RawMessage, error) {
 	payload := strings.TrimSpace(value)
-	if payload == "" {
-		return nil, fmt.Errorf("job payload must be valid JSON")
-	}
-	if !json.Valid([]byte(payload)) {
+	if payload == "" || !json.Valid([]byte(payload)) {
 		return nil, fmt.Errorf("job payload must be valid JSON")
 	}
 	return json.RawMessage(payload), nil

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -90,6 +90,19 @@ type Options struct {
 	Jobs          []dygo.JobRegistrar
 }
 
+func newCommandGroup(use string, short string, aliases ...string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   short,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	return cmd
+}
+
 var startStudioDevServer = startStudioDevServerProcess
 
 // Run executes the dygo command-line interface.
@@ -99,24 +112,32 @@ func Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 
 // RunWithOptions executes the dygo command-line interface with compiled extensions.
 func RunWithOptions(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, options Options) error {
+	dependencies, err := newCommandDependencies(options)
+	if err != nil {
+		return err
+	}
+	return execute(ctx, args, stdin, stdout, stderr, dependencies)
+}
+
+func newCommandDependencies(options Options) (commandDependencies, error) {
 	migrator := db.NewMigrator()
 	recordHooks, err := recordhooks.NewRecordHookRegistry(options.RecordHooks)
 	if err != nil {
-		return fmt.Errorf("configure record hooks: %w", err)
+		return commandDependencies{}, fmt.Errorf("configure record hooks: %w", err)
 	}
 	actionRegistry, err := entityactions.NewRegistry(options.EntityActions)
 	if err != nil {
-		return fmt.Errorf("configure Entity actions: %w", err)
+		return commandDependencies{}, fmt.Errorf("configure Entity actions: %w", err)
 	}
 	jobRegistrars := append([]dygo.JobRegistrar{filedata.CleanupJobRegistrar(), importsvc.JobRegistrar()}, options.Jobs...)
 	jobRegistry, err := jobruntime.NewRegistry(jobRegistrars)
 	if err != nil {
-		return fmt.Errorf("configure jobs: %w", err)
+		return commandDependencies{}, fmt.Errorf("configure jobs: %w", err)
 	}
-	return execute(ctx, args, stdin, stdout, stderr, commandDependencies{
+	return commandDependencies{
 		serve: server.Serve, database: db.NewManager(migrator), sync: migrator, setup: defaultAdminSetupRunner{}, fixture: defaultFixtureRunner{recordHooks: recordHooks},
 		access: defaultAccessRunner{}, recordHooks: recordHooks, actionRegistry: actionRegistry, jobRegistry: jobRegistry,
-	})
+	}, nil
 }
 
 func execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, dependencies commandDependencies) error {
@@ -136,24 +157,11 @@ func execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 
 // NewRootCommand creates the root dygo CLI command.
 func NewRootCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) (*cobra.Command, error) {
-	migrator := db.NewMigrator()
-	recordHooks, err := recordhooks.NewRecordHookRegistry(nil)
+	dependencies, err := newCommandDependencies(Options{})
 	if err != nil {
-		return nil, fmt.Errorf("configure record hooks: %w", err)
+		return nil, err
 	}
-	actionRegistry, err := entityactions.NewRegistry(nil)
-	if err != nil {
-		return nil, fmt.Errorf("configure Entity actions: %w", err)
-	}
-	jobRegistry, err := jobruntime.NewRegistry([]dygo.JobRegistrar{filedata.CleanupJobRegistrar(), importsvc.JobRegistrar()})
-	if err != nil {
-		return nil, fmt.Errorf("configure jobs: %w", err)
-	}
-	return newRootCommand(ctx, stdin, stdout, stderr, commandDependencies{
-		serve: server.Serve, database: db.NewManager(migrator), sync: migrator, setup: defaultAdminSetupRunner{},
-		fixture: defaultFixtureRunner{recordHooks: recordHooks}, access: defaultAccessRunner{}, recordHooks: recordHooks,
-		actionRegistry: actionRegistry, jobRegistry: jobRegistry,
-	})
+	return newRootCommand(ctx, stdin, stdout, stderr, dependencies)
 }
 
 func newRootCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, dependencies commandDependencies) (*cobra.Command, error) {

--- a/internal/cli/routes.go
+++ b/internal/cli/routes.go
@@ -15,14 +15,7 @@ import (
 )
 
 func newRouteCommand(stdout io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "route",
-		Short: "Inspect and validate dygo routes",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("route", "Inspect and validate dygo routes")
 
 	cmd.AddCommand(newRouteListCommand(stdout))
 	cmd.AddCommand(newRouteValidateCommand(stdout))

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -15,14 +15,7 @@ import (
 )
 
 func newSecretCommand(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "secret",
-		Short: "Manage encrypted dygo secrets",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	cmd := newCommandGroup("secret", "Manage encrypted dygo secrets")
 
 	cmd.AddCommand(newRecordKeyCommand(ctx, stdout))
 	cmd.AddCommand(newSecretInitCommand(stdout))
@@ -48,7 +41,7 @@ func newSecretInitCommand(stdout io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(stdout, "initialized secrets\nkey: %s\n%s", rel(paths.MasterKeyFile), formatSecretFiles(store)); err != nil {
+			if _, err := fmt.Fprintf(stdout, "initialized secrets\nkey: %s\n%s", relToWorkingRoot(paths.MasterKeyFile), formatSecretFiles(store)); err != nil {
 				return fmt.Errorf("write init output: %w", err)
 			}
 			return nil
@@ -179,7 +172,7 @@ func newSecretRotateKeyCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra
 			if err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(stdout, "rotated secrets master key\nkey: %s\n%s", rel(paths.MasterKeyFile), formatSecretFiles(store)); err != nil {
+			if _, err := fmt.Fprintf(stdout, "rotated secrets master key\nkey: %s\n%s", relToWorkingRoot(paths.MasterKeyFile), formatSecretFiles(store)); err != nil {
 				return fmt.Errorf("write rotate-key output: %w", err)
 			}
 			return nil
@@ -200,7 +193,7 @@ func newWorkingSecretsStore() (secrets.Store, error) {
 }
 
 func writeRotateKeyPlan(stdout io.Writer, store secrets.Store) error {
-	if _, err := fmt.Fprintf(stdout, "secret rotate-key plan\nkey: %s\n%s", rel(store.Paths(secrets.EnvironmentDevelopment).MasterKeyFile), formatSecretFiles(store)); err != nil {
+	if _, err := fmt.Fprintf(stdout, "secret rotate-key plan\nkey: %s\n%s", relToWorkingRoot(store.Paths(secrets.EnvironmentDevelopment).MasterKeyFile), formatSecretFiles(store)); err != nil {
 		return fmt.Errorf("write rotate-key plan: %w", err)
 	}
 	return nil
@@ -311,12 +304,8 @@ func formatSecretFiles(store secrets.Store) string {
 	builder.WriteString("files:\n")
 	for _, env := range secrets.SupportedEnvironments() {
 		builder.WriteString("  ")
-		builder.WriteString(rel(store.Paths(env).SecretFile))
+		builder.WriteString(relToWorkingRoot(store.Paths(env).SecretFile))
 		builder.WriteString("\n")
 	}
 	return builder.String()
-}
-
-func rel(path string) string {
-	return relToWorkingRoot(path)
 }

--- a/internal/db/activity.go
+++ b/internal/db/activity.go
@@ -125,9 +125,6 @@ func (r ActivityReader) AddEventByIdentity(ctx context.Context, appName string, 
 }
 
 func (r ActivityReader) addEvent(ctx context.Context, entity string, entityID int64, entityName string, recordID int64, event TimelineEvent) error {
-	if err := r.requireQueryer(); err != nil {
-		return err
-	}
 	if recordID <= 0 {
 		return invalidRecordIDError(entity)
 	}

--- a/internal/db/records.go
+++ b/internal/db/records.go
@@ -126,14 +126,10 @@ func NewRecordStore(queryer RecordQueryer) RecordStore {
 
 // NewRecordStoreWithHookPolicy returns a Record store backed by queryer and an explicit hook policy.
 func NewRecordStoreWithHookPolicy(queryer RecordQueryer, policy RecordMutationHookPolicy) RecordStore {
-	switch policy {
-	case RecordMutationHooksNone:
+	if policy == RecordMutationHooksNone {
 		return NewRecordStoreWithHooks(queryer, nil)
-	case RecordMutationHooksFrameworkOnly, "":
-		return NewRecordStoreWithHooks(queryer, DefaultRecordHookRegistry())
-	default:
-		return NewRecordStoreWithHooks(queryer, DefaultRecordHookRegistry())
 	}
+	return NewRecordStoreWithHooks(queryer, DefaultRecordHookRegistry())
 }
 
 // NewRecordStoreWithHooks returns a Record store backed by queryer and hooks.
@@ -671,10 +667,6 @@ func (s RecordStore) updateRecordWithLayout(ctx context.Context, layout recordLa
 		return nil, err
 	}
 	changes := layout.activityChanges(input, oldRecord, record)
-	recordID, err = activityRecordID(record)
-	if err != nil {
-		return nil, err
-	}
 	afterCtx := newRecordHookContext(RecordAfterUpdate, layout)
 	afterCtx.Operation = corevalues.ActivityOperationUpdate
 	afterCtx.RecordID = recordID
@@ -1916,11 +1908,6 @@ func normalizeRecordValue(fieldType string, value any) any {
 			}
 			return typed
 		}
-	case float64:
-		if math.Trunc(typed) == typed {
-			return typed
-		}
-		return typed
 	default:
 		return typed
 	}

--- a/internal/db/schema_plan.go
+++ b/internal/db/schema_plan.go
@@ -335,15 +335,13 @@ func buildDesiredSchema(entities []catalog.LoadedEntity) (desiredSchema, error) 
 			Constraints:   []desiredConstraint{},
 		}
 		desiredTable.CreateSQL = createTableSQL(table, desiredTable.SystemColumns)
-		if requiresSystemNameUniqueConstraint(loaded) {
-			desiredTable.Constraints = append(desiredTable.Constraints, desiredConstraint{
-				Name:       constraintName(table, "name", "key"),
-				Type:       "unique",
-				Columns:    []string{"name"},
-				Definition: fmt.Sprintf("UNIQUE (%s)", quoteIdentList([]string{"name"})),
-				Source:     entitySource(loaded),
-			})
-		}
+		desiredTable.Constraints = append(desiredTable.Constraints, desiredConstraint{
+			Name:       constraintName(table, "name", "key"),
+			Type:       "unique",
+			Columns:    []string{"name"},
+			Definition: fmt.Sprintf("UNIQUE (%s)", quoteIdentList([]string{"name"})),
+			Source:     entitySource(loaded),
+		})
 		if loaded.Entity.IsSingle {
 			desiredTable.Constraints = append(desiredTable.Constraints, singleEntityNameConstraint(table, loaded))
 		}
@@ -548,10 +546,6 @@ func validateDesiredObjectNames(table desiredTable) error {
 		constraintNames[constraint.Name] = constraint.Source
 	}
 	return nil
-}
-
-func requiresSystemNameUniqueConstraint(entity catalog.LoadedEntity) bool {
-	return true
 }
 
 func singleEntityNameConstraint(table string, entity catalog.LoadedEntity) desiredConstraint {

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -359,9 +359,6 @@ func validateUpload(upload dygo.FileUpload) error {
 	if upload.Size < -1 || upload.Size > maxFileSize {
 		return fileError("invalid_request", "file size is invalid")
 	}
-	if !hasTarget(upload.Target) && upload.Size == 0 {
-		return nil
-	}
 	return nil
 }
 

--- a/internal/frameworkapp/assets.go
+++ b/internal/frameworkapp/assets.go
@@ -3,13 +3,13 @@ package frameworkapp
 
 import (
 	"embed"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/hapyco/dygo/internal/fsutil"
 	"github.com/hapyco/dygo/internal/shape"
 )
 
@@ -58,17 +58,7 @@ func EmbeddedCoreSource() (Source, error) {
 
 // HasManifest reports whether fsys contains an App manifest.
 func HasManifest(fsys fs.FS) (bool, error) {
-	if fsys == nil {
-		return false, nil
-	}
-	info, err := fs.Stat(fsys, "app.yml")
-	if err == nil {
-		return !info.IsDir(), nil
-	}
-	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	return false, err
+	return fsutil.HasFile(fsys, "app.yml")
 }
 
 // InstallCore installs the first valid Core source into a generated project.
@@ -84,85 +74,21 @@ func InstallCore(root string, sources ...Source) (string, error) {
 		if !ok {
 			continue
 		}
-		if err := replaceCoreDir(source.FS, filepath.Join(root, filepath.FromSlash(CoreProjectPath))); err != nil {
+		target := filepath.Join(root, filepath.FromSlash(CoreProjectPath))
+		if err := fsutil.ReplaceDir(target, ".core-app-*", "Core App", func(temp string) error {
+			if err := fsutil.CopyFS(source.FS, temp, "Core App asset"); err != nil {
+				return err
+			}
+			if ok, err := HasManifest(os.DirFS(temp)); err != nil {
+				return fmt.Errorf("verify temporary Core App cache: %w", err)
+			} else if !ok {
+				return fmt.Errorf("temporary Core App cache is missing app.yml")
+			}
+			return nil
+		}); err != nil {
 			return "", fmt.Errorf("install %s: %w", source.Name, err)
 		}
 		return source.Name, nil
 	}
 	return "", fmt.Errorf("Core App assets are unavailable")
-}
-
-func replaceCoreDir(source fs.FS, target string) error {
-	parent := filepath.Dir(target)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return fmt.Errorf("create Core App cache parent: %w", err)
-	}
-	temp, err := os.MkdirTemp(parent, ".core-app-*")
-	if err != nil {
-		return fmt.Errorf("create temporary Core App cache: %w", err)
-	}
-	defer func() {
-		if temp != "" {
-			_ = os.RemoveAll(temp)
-		}
-	}()
-
-	if err := copyFS(source, temp); err != nil {
-		return err
-	}
-	if ok, err := HasManifest(os.DirFS(temp)); err != nil {
-		return fmt.Errorf("verify temporary Core App cache: %w", err)
-	} else if !ok {
-		return fmt.Errorf("temporary Core App cache is missing app.yml")
-	}
-
-	backup := target + ".previous"
-	_ = os.RemoveAll(backup)
-	hadExisting := false
-	if _, err := os.Stat(target); err == nil {
-		hadExisting = true
-		if err := os.Rename(target, backup); err != nil {
-			return fmt.Errorf("move existing Core App cache aside: %w", err)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("check existing Core App cache: %w", err)
-	}
-
-	if err := os.Rename(temp, target); err != nil {
-		if hadExisting {
-			_ = os.Rename(backup, target)
-		}
-		return fmt.Errorf("replace Core App cache: %w", err)
-	}
-	temp = ""
-	if hadExisting {
-		_ = os.RemoveAll(backup)
-	}
-	return nil
-}
-
-func copyFS(source fs.FS, target string) error {
-	return fs.WalkDir(source, ".", func(name string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if name == "." {
-			return nil
-		}
-		destination := filepath.Join(target, filepath.FromSlash(name))
-		if entry.IsDir() {
-			return os.MkdirAll(destination, 0o755)
-		}
-		data, err := fs.ReadFile(source, name)
-		if err != nil {
-			return fmt.Errorf("read Core App asset %s: %w", name, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
-			return fmt.Errorf("create Core App asset directory %s: %w", name, err)
-		}
-		if err := os.WriteFile(destination, data, 0o644); err != nil {
-			return fmt.Errorf("write Core App asset %s: %w", name, err)
-		}
-		return nil
-	})
 }

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -1,0 +1,99 @@
+// Package fsutil contains filesystem operations shared by framework installers.
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ReplaceDir prepares a directory and replaces target with it atomically.
+func ReplaceDir(target, pattern, label string, prepare func(string) error) error {
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create %s cache parent: %w", label, err)
+	}
+	temp, err := os.MkdirTemp(parent, pattern)
+	if err != nil {
+		return fmt.Errorf("create temporary %s cache: %w", label, err)
+	}
+	defer func() {
+		if temp != "" {
+			_ = os.RemoveAll(temp)
+		}
+	}()
+
+	if err := prepare(temp); err != nil {
+		return err
+	}
+
+	backup := target + ".previous"
+	_ = os.RemoveAll(backup)
+	hadExisting := false
+	if _, err := os.Stat(target); err == nil {
+		hadExisting = true
+		if err := os.Rename(target, backup); err != nil {
+			return fmt.Errorf("move existing %s cache aside: %w", label, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("check existing %s cache: %w", label, err)
+	}
+	if err := os.Rename(temp, target); err != nil {
+		if hadExisting {
+			_ = os.Rename(backup, target)
+		}
+		return fmt.Errorf("replace %s cache: %w", label, err)
+	}
+	temp = ""
+	if hadExisting {
+		_ = os.RemoveAll(backup)
+	}
+	return nil
+}
+
+// CopyFS copies all files and directories in source below target.
+func CopyFS(source fs.FS, target, label string) error {
+	return fs.WalkDir(source, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if name == "." {
+			return nil
+		}
+		destination := filepath.Join(target, filepath.FromSlash(name))
+		if entry.IsDir() {
+			if err := os.MkdirAll(destination, 0o755); err != nil {
+				return fmt.Errorf("create %s directory %s: %w", label, name, err)
+			}
+			return nil
+		}
+		data, err := fs.ReadFile(source, name)
+		if err != nil {
+			return fmt.Errorf("read %s %s: %w", label, name, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+			return fmt.Errorf("create %s parent %s: %w", label, name, err)
+		}
+		if err := os.WriteFile(destination, data, 0o644); err != nil {
+			return fmt.Errorf("write %s %s: %w", label, name, err)
+		}
+		return nil
+	})
+}
+
+// HasFile reports whether fsys contains the named regular file.
+func HasFile(fsys fs.FS, name string) (bool, error) {
+	if fsys == nil {
+		return false, nil
+	}
+	info, err := fs.Stat(fsys, name)
+	if err == nil {
+		return !info.IsDir(), nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/pages/pages.go
+++ b/internal/pages/pages.go
@@ -236,9 +236,6 @@ func ValidatePage(p dygo.Page) error {
 	} else if p.Renderer != "entity-index" {
 		problems = append(problems, fmt.Sprintf("renderer %q is not supported", p.Renderer))
 	}
-	if p.Options == nil {
-		p.Options = map[string]any{}
-	}
 	if len(problems) > 0 {
 		return ValidationError{Problems: problems}
 	}

--- a/internal/project/metadata.go
+++ b/internal/project/metadata.go
@@ -86,6 +86,10 @@ func LoadSchedules(apps []manifest.LoadedApp, loadedJobs []jobs.LoadedJob) ([]sc
 
 // LoadMetadata loads the validated app and Entity metadata context for a project root.
 func LoadMetadata(root string) (Metadata, error) {
+	return loadBaseMetadata(root)
+}
+
+func loadBaseMetadata(root string) (Metadata, error) {
 	apps, err := LoadApps(root)
 	if err != nil {
 		return Metadata{}, err
@@ -103,15 +107,7 @@ func LoadMetadata(root string) (Metadata, error) {
 
 // LoadRuntimeMetadata loads metadata needed by database runtime sync.
 func LoadRuntimeMetadata(root string) (RuntimeMetadata, error) {
-	apps, err := LoadApps(root)
-	if err != nil {
-		return RuntimeMetadata{}, err
-	}
-	entities, err := LoadEntities(apps)
-	if err != nil {
-		return RuntimeMetadata{}, err
-	}
-	loadedPages, err := LoadPages(apps)
+	base, err := loadBaseMetadata(root)
 	if err != nil {
 		return RuntimeMetadata{}, err
 	}
@@ -119,13 +115,13 @@ func LoadRuntimeMetadata(root string) (RuntimeMetadata, error) {
 	if err != nil {
 		return RuntimeMetadata{}, err
 	}
-	loadedJobs, err := LoadJobs(apps, queueConfig)
+	loadedJobs, err := LoadJobs(base.Apps, queueConfig)
 	if err != nil {
 		return RuntimeMetadata{}, err
 	}
-	loadedSchedules, err := LoadSchedules(apps, loadedJobs)
+	loadedSchedules, err := LoadSchedules(base.Apps, loadedJobs)
 	if err != nil {
 		return RuntimeMetadata{}, err
 	}
-	return RuntimeMetadata{Apps: apps, Entities: entities, Pages: loadedPages, Queues: queueConfig, Jobs: loadedJobs, Schedules: loadedSchedules}, nil
+	return RuntimeMetadata{Apps: base.Apps, Entities: base.Entities, Pages: base.Pages, Queues: queueConfig, Jobs: loadedJobs, Schedules: loadedSchedules}, nil
 }

--- a/internal/recordfilter/operators.go
+++ b/internal/recordfilter/operators.go
@@ -47,50 +47,30 @@ var operatorsByKey = map[string]Operator{
 	OperatorNotEmpty:           {Key: OperatorNotEmpty, Label: "is not empty", Arity: ArityNone},
 }
 
-var profileByFieldType = map[string][]string{
-	"link": {
+var (
+	basicOperators = []string{
 		OperatorEqual,
 		OperatorNotEqual,
 		OperatorEmpty,
 		OperatorNotEmpty,
-	},
-	"select": {
-		OperatorEqual,
-		OperatorNotEqual,
-		OperatorEmpty,
-		OperatorNotEmpty,
-	},
-	"boolean": {
-		OperatorEqual,
-		OperatorNotEqual,
-		OperatorEmpty,
-		OperatorNotEmpty,
-	},
-	"date": {
+	}
+	temporalOperators = []string{
 		OperatorEqual,
 		OperatorBefore,
 		OperatorAfter,
 		OperatorBetween,
 		OperatorEmpty,
 		OperatorNotEmpty,
-	},
-	"datetime": {
-		OperatorEqual,
-		OperatorBefore,
-		OperatorAfter,
-		OperatorBetween,
-		OperatorEmpty,
-		OperatorNotEmpty,
-	},
-	"time": {
-		OperatorEqual,
-		OperatorBefore,
-		OperatorAfter,
-		OperatorBetween,
-		OperatorEmpty,
-		OperatorNotEmpty,
-	},
-}
+	}
+	profileByFieldType = map[string][]string{
+		"link":     basicOperators,
+		"select":   basicOperators,
+		"boolean":  basicOperators,
+		"date":     temporalOperators,
+		"datetime": temporalOperators,
+		"time":     temporalOperators,
+	}
+)
 
 var numericOperators = []string{
 	OperatorEqual,

--- a/internal/routes/registry.go
+++ b/internal/routes/registry.go
@@ -122,15 +122,18 @@ func Validate(entities []catalog.LoadedEntity) (ValidationResult, error) {
 
 // ValidateWithPages checks the static public route registry including Page claims.
 func ValidateWithPages(entities []catalog.LoadedEntity, loadedPages []pages.LoadedPage) (ValidationResult, error) {
-	entityRoutes := EntriesWithPages(entities, loadedPages)
-	result := ValidationResult{
-		ReservedRoutes: len(ReservedSlugs()),
-		EntityRoutes:   len(entityRoutes) - countEntries(entityRoutes, "page"),
-		PageRoutes:     countEntries(entityRoutes, "page"),
-	}
+	result := ValidationResult{}
 	claims := map[string][]RegistryEntry{}
 	for _, route := range RegistryWithPages(entities, loadedPages) {
 		claims[route.Path] = append(claims[route.Path], route)
+		switch route.Kind {
+		case "reserved":
+			result.ReservedRoutes++
+		case "page":
+			result.PageRoutes++
+		default:
+			result.EntityRoutes++
+		}
 	}
 
 	var paths []string
@@ -154,16 +157,6 @@ func ValidateWithPages(entities []catalog.LoadedEntity, loadedPages []pages.Load
 	}
 	result.Conflicts = len(problems)
 	return result, ValidationError{Problems: problems}
-}
-
-func countEntries(entries []Entry, kind string) int {
-	count := 0
-	for _, entry := range entries {
-		if entry.Kind == kind {
-			count++
-		}
-	}
-	return count
 }
 
 // ReservedSlugs returns framework-reserved root route slugs without a leading slash.

--- a/internal/schedules/schedules.go
+++ b/internal/schedules/schedules.go
@@ -57,10 +57,7 @@ type Schedule struct {
 
 // EffectiveEnabled returns whether this Schedule should create future Job Executions.
 func (s Schedule) EffectiveEnabled() bool {
-	if s.Enabled == nil {
-		return true
-	}
-	return *s.Enabled
+	return s.Enabled == nil || *s.Enabled
 }
 
 // JobRef returns the target app/job reference.

--- a/internal/studio/assets.go
+++ b/internal/studio/assets.go
@@ -3,7 +3,6 @@ package studio
 
 import (
 	"embed"
-	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -11,6 +10,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/hapyco/dygo/internal/fsutil"
 )
 
 const (
@@ -128,17 +129,11 @@ func defaultEmbeddedSource() (Source, bool, error) {
 
 // HasIndex reports whether fsys contains a built Studio entrypoint.
 func HasIndex(fsys fs.FS) (bool, error) {
-	if fsys == nil {
-		return false, nil
-	}
-	info, err := fs.Stat(fsys, "index.html")
-	if err == nil {
-		return !info.IsDir(), nil
-	}
-	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	return false, err
+	return fsutil.HasFile(fsys, "index.html")
+}
+
+func hasManifest(fsys fs.FS) (bool, error) {
+	return fsutil.HasFile(fsys, "app.yml")
 }
 
 // NewStaticHandler serves built Studio assets with SPA route fallback.
@@ -263,76 +258,26 @@ func firstAssetSource(sources []Source) (Source, error) {
 	return Source{}, fmt.Errorf("Studio UI assets are unavailable")
 }
 
-func hasManifest(fsys fs.FS) (bool, error) {
-	if fsys == nil {
-		return false, nil
-	}
-	info, err := fs.Stat(fsys, "app.yml")
-	if err == nil {
-		return !info.IsDir(), nil
-	}
-	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	return false, err
-}
-
 func replaceAppDir(appSource fs.FS, assetSource fs.FS, target string) error {
-	parent := filepath.Dir(target)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return fmt.Errorf("create Studio App cache parent: %w", err)
-	}
-	temp, err := os.MkdirTemp(parent, ".studio-app-*")
-	if err != nil {
-		return fmt.Errorf("create temporary Studio App cache: %w", err)
-	}
-	defer func() {
-		if temp != "" {
-			_ = os.RemoveAll(temp)
+	return fsutil.ReplaceDir(target, ".studio-app-*", "Studio App", func(temp string) error {
+		if err := copyAppMetadata(appSource, temp); err != nil {
+			return err
 		}
-	}()
-
-	if err := copyAppMetadata(appSource, temp); err != nil {
-		return err
-	}
-	if err := copyFS(assetSource, filepath.Join(temp, "ui", "dist")); err != nil {
-		return err
-	}
-	if ok, err := hasManifest(os.DirFS(temp)); err != nil {
-		return fmt.Errorf("verify temporary Studio App cache: %w", err)
-	} else if !ok {
-		return fmt.Errorf("temporary Studio App cache is missing app.yml")
-	}
-	if ok, err := HasIndex(os.DirFS(filepath.Join(temp, "ui", "dist"))); err != nil {
-		return fmt.Errorf("verify temporary Studio UI cache: %w", err)
-	} else if !ok {
-		return fmt.Errorf("temporary Studio UI cache is missing index.html")
-	}
-
-	// TODO(packaging): share this guarded directory swap with frameworkapp once
-	// framework App installation has one package-level primitive.
-	backup := target + ".previous"
-	_ = os.RemoveAll(backup)
-	hadExisting := false
-	if _, err := os.Stat(target); err == nil {
-		hadExisting = true
-		if err := os.Rename(target, backup); err != nil {
-			return fmt.Errorf("move existing Studio App cache aside: %w", err)
+		if err := fsutil.CopyFS(assetSource, filepath.Join(temp, "ui", "dist"), "Studio asset"); err != nil {
+			return err
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("check existing Studio App cache: %w", err)
-	}
-	if err := os.Rename(temp, target); err != nil {
-		if hadExisting {
-			_ = os.Rename(backup, target)
+		if ok, err := hasManifest(os.DirFS(temp)); err != nil {
+			return fmt.Errorf("verify temporary Studio App cache: %w", err)
+		} else if !ok {
+			return fmt.Errorf("temporary Studio App cache is missing app.yml")
 		}
-		return fmt.Errorf("replace Studio App cache: %w", err)
-	}
-	temp = ""
-	if hadExisting {
-		_ = os.RemoveAll(backup)
-	}
-	return nil
+		if ok, err := HasIndex(os.DirFS(filepath.Join(temp, "ui", "dist"))); err != nil {
+			return fmt.Errorf("verify temporary Studio UI cache: %w", err)
+		} else if !ok {
+			return fmt.Errorf("temporary Studio UI cache is missing index.html")
+		}
+		return nil
+	})
 }
 
 func copyAppMetadata(source fs.FS, target string) error {
@@ -391,78 +336,14 @@ func assetExists(fsys fs.FS, name string) bool {
 }
 
 func replaceDir(source fs.FS, target string) error {
-	parent := filepath.Dir(target)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return fmt.Errorf("create Studio cache parent: %w", err)
-	}
-	temp, err := os.MkdirTemp(parent, ".studio-dist-*")
-	if err != nil {
-		return fmt.Errorf("create temporary Studio cache: %w", err)
-	}
-	defer func() {
-		if temp != "" {
-			_ = os.RemoveAll(temp)
-		}
-	}()
-
-	if err := copyFS(source, temp); err != nil {
-		return err
-	}
-	if ok, err := HasIndex(os.DirFS(temp)); err != nil {
-		return fmt.Errorf("verify temporary Studio cache: %w", err)
-	} else if !ok {
-		return fmt.Errorf("temporary Studio cache is missing index.html")
-	}
-
-	backup := target + ".previous"
-	_ = os.RemoveAll(backup)
-	hadExisting := false
-	if _, err := os.Stat(target); err == nil {
-		hadExisting = true
-		if err := os.Rename(target, backup); err != nil {
-			return fmt.Errorf("move existing Studio cache aside: %w", err)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("check existing Studio cache: %w", err)
-	}
-
-	if err := os.Rename(temp, target); err != nil {
-		if hadExisting {
-			_ = os.Rename(backup, target)
-		}
-		return fmt.Errorf("replace Studio cache: %w", err)
-	}
-	temp = ""
-	if hadExisting {
-		_ = os.RemoveAll(backup)
-	}
-	return nil
-}
-
-func copyFS(source fs.FS, target string) error {
-	return fs.WalkDir(source, ".", func(name string, entry fs.DirEntry, err error) error {
-		if err != nil {
+	return fsutil.ReplaceDir(target, ".studio-dist-*", "Studio", func(temp string) error {
+		if err := fsutil.CopyFS(source, temp, "Studio asset"); err != nil {
 			return err
 		}
-		if name == "." {
-			return nil
-		}
-		targetPath := filepath.Join(target, filepath.FromSlash(name))
-		if entry.IsDir() {
-			if err := os.MkdirAll(targetPath, 0o755); err != nil {
-				return fmt.Errorf("create Studio asset directory %s: %w", name, err)
-			}
-			return nil
-		}
-		data, err := fs.ReadFile(source, name)
-		if err != nil {
-			return fmt.Errorf("read Studio asset %s: %w", name, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-			return fmt.Errorf("create Studio asset parent %s: %w", name, err)
-		}
-		if err := os.WriteFile(targetPath, data, 0o644); err != nil {
-			return fmt.Errorf("write Studio asset %s: %w", name, err)
+		if ok, err := HasIndex(os.DirFS(temp)); err != nil {
+			return fmt.Errorf("verify temporary Studio cache: %w", err)
+		} else if !ok {
+			return fmt.Errorf("temporary Studio cache is missing index.html")
 		}
 		return nil
 	})


### PR DESCRIPTION
Summary: consolidate duplicated framework asset installation, CLI command-group/dependency/output plumbing, Studio record-field helpers, route and metadata loading; remove stale and repeated documentation; simplify redundant branches while preserving behavior and all UI components. Tests: go test ./..., go vet ./..., npm test, npm run build, npm run build:embed.