### PR TITLE
feat: add Studio cancel and retry for Job Executions

### DIFF
--- a/apps/core/access/job-execution.access.yml
+++ b/apps/core/access/job-execution.access.yml
@@ -1,0 +1,3 @@
+policy:
+  - role: system-manager
+    can: [read, export, print, cancel, retry]

--- a/apps/core/access/job.access.yml
+++ b/apps/core/access/job.access.yml
@@ -1,0 +1,3 @@
+policy:
+  - role: system-manager
+    can: [read, export, print]

--- a/apps/studio/ui/src/features/metadata/metadata.api.ts
+++ b/apps/studio/ui/src/features/metadata/metadata.api.ts
@@ -88,6 +88,8 @@ export type EntityActionDefinition = {
   name: string
   label: string
   selection: 'record' | 'selection' | 'collection'
+  confirm?: string
+  danger?: boolean
 }
 
 type MetadataRequestOptions = {

--- a/apps/studio/ui/src/features/records/entity-actions.test.ts
+++ b/apps/studio/ui/src/features/records/entity-actions.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  entityActionConfirm,
+  entityActionDisabledReason,
+  recordEntityActions,
+} from './entity-actions.ts'
+
+test('recordEntityActions keeps only record selection actions', () => {
+  const actions = recordEntityActions([
+    { name: 'cancel', label: 'Cancel', selection: 'record' },
+    { name: 'bulk-close', label: 'Close', selection: 'selection' },
+    { name: 'reindex', label: 'Reindex', selection: 'collection' },
+  ])
+
+  assert.deepEqual(actions.map((action) => action.name), ['cancel'])
+})
+
+test('entityActionDisabledReason gates Job Execution cancel and retry', () => {
+  assert.equal(entityActionDisabledReason('job-execution', 'cancel', null), 'Record unavailable')
+  assert.equal(entityActionDisabledReason('job-execution', 'cancel', { status: 'queued' }), undefined)
+  assert.equal(
+    entityActionDisabledReason('job-execution', 'cancel', { status: 'running' }),
+    'Only queued Job Executions can be cancelled',
+  )
+  assert.equal(entityActionDisabledReason('job-execution', 'retry', { status: 'failed' }), undefined)
+  assert.equal(
+    entityActionDisabledReason('job-execution', 'retry', { status: 'queued' }),
+    'Only failed Job Executions can be retried',
+  )
+  assert.equal(entityActionDisabledReason('lead', 'cancel', { status: 'open' }), undefined)
+})
+
+test('entityActionConfirm uses action metadata', () => {
+  assert.equal(entityActionConfirm({ name: 'archive', label: 'Archive', selection: 'record' }), null)
+  assert.deepEqual(
+    entityActionConfirm({
+      name: 'cancel',
+      label: 'Cancel',
+      selection: 'record',
+      confirm: 'This queued Job Execution will not run.',
+      danger: true,
+    }),
+    {
+      title: 'Cancel?',
+      content: 'This queued Job Execution will not run.',
+      type: 'danger',
+    },
+  )
+  assert.deepEqual(
+    entityActionConfirm({
+      name: 'retry',
+      label: 'Retry',
+      selection: 'record',
+      confirm: 'dygo will queue a new Job Execution with the same payload.',
+    }),
+    {
+      title: 'Retry?',
+      content: 'dygo will queue a new Job Execution with the same payload.',
+      type: 'warning',
+    },
+  )
+})

--- a/apps/studio/ui/src/features/records/entity-actions.ts
+++ b/apps/studio/ui/src/features/records/entity-actions.ts
@@ -1,0 +1,49 @@
+import type { StudioDialogType } from '@/features/dialogs/dialogs.store'
+import type { EntityActionDefinition } from '@/features/metadata/metadata.api'
+
+import type { RecordData } from './records.api'
+
+export type EntityActionConfirm = {
+  title: string
+  content: string
+  type: StudioDialogType
+}
+
+export function recordEntityActions(actions: EntityActionDefinition[] | undefined): EntityActionDefinition[] {
+  return (actions ?? []).filter((action): action is EntityActionDefinition => Boolean(action) && action.selection === 'record')
+}
+
+export function entityActionDisabledReason(
+  entityKey: string,
+  actionName: string,
+  record: RecordData | null | undefined,
+): string | undefined {
+  if (!record) {
+    return 'Record unavailable'
+  }
+  if (entityKey !== 'job-execution') {
+    return undefined
+  }
+
+  const status = typeof record.status === 'string' ? record.status : ''
+  if (actionName === 'cancel' && status !== 'queued') {
+    return 'Only queued Job Executions can be cancelled'
+  }
+  if (actionName === 'retry' && status !== 'failed') {
+    return 'Only failed Job Executions can be retried'
+  }
+  return undefined
+}
+
+export function entityActionConfirm(action: EntityActionDefinition): EntityActionConfirm | null {
+  const content = action.confirm?.trim() ?? ''
+  if (!content) {
+    return null
+  }
+
+  return {
+    title: `${action.label}?`,
+    content,
+    type: action.danger ? 'danger' : 'warning',
+  }
+}

--- a/apps/studio/ui/src/pages/RecordFormPage.vue
+++ b/apps/studio/ui/src/pages/RecordFormPage.vue
@@ -233,8 +233,8 @@ const canSave = computed(() => showForm.value && dirty.value && !loading.value &
 const confirmDiscard = useDraftGuard(() => dirty.value, () => saving.value)
 const saveDisabledReason = computed(() => isSystem.value ? 'Read-only Record' : loading.value ? 'Loading Record' : saving.value ? 'Saving Record' : !showForm.value ? 'Record unavailable' : !dirty.value ? 'No changes' : undefined)
 usePageCommands(computed(() => [
-  { id: 'record:save', label: isNew.value ? 'Create Record' : 'Save Record', disabledReason: saveDisabledReason.value, run: saveRecord },
-  { id: 'record:reset', label: 'Reset changes', disabledReason: !dirty.value ? 'No changes' : loading.value || saving.value ? 'Record is busy' : isSystem.value ? 'Read-only Record' : undefined, run: resetDraft },
+  { id: 'record:save', label: isNew.value ? 'Create Record' : 'Save Record', disabledReason: entityActionMutation.isPending.value ? 'Action is running' : saveDisabledReason.value, run: saveRecord },
+  { id: 'record:reset', label: 'Reset changes', disabledReason: !dirty.value ? 'No changes' : loading.value || saving.value || entityActionMutation.isPending.value ? 'Record is busy' : isSystem.value ? 'Read-only Record' : undefined, run: resetDraft },
   ...(!isSingle.value ? [{ id: 'record:list', label: 'Go to Entity list', run: async () => { await router.push({ name: RouteName.EntityRecords, params: { entity: props.entity } }) } }] : []),
 ]))
 const entityActions = computed(() => recordEntityActions(entityMeta.value?.actions))

--- a/apps/studio/ui/src/pages/RecordFormPage.vue
+++ b/apps/studio/ui/src/pages/RecordFormPage.vue
@@ -4,14 +4,23 @@ import { useRouter } from 'vue-router'
 import { usePageCommands, runStudioCommand } from '@/features/commands/context'
 import { bindings } from '@/features/commands/shortcuts'
 import { useDraftGuard } from '@/features/records/use-draft-guard'
-import { Plus, RotateCcw, Save, Trash2 } from '@lucide/vue'
+import { Ban, Play, Plus, RotateCcw, Save, Trash2 } from '@lucide/vue'
 
+import { queryClient } from '@/app/query'
 import { ErrorState, Spinner } from '@/design'
 import { useDialog } from '@/features/dialogs/use-dialog'
 import { useToast } from '@/features/toasts/use-toast'
-import type { MetadataEntityMeta, MetadataField } from '@/features/metadata/metadata.api'
+import type { EntityActionDefinition, MetadataEntityMeta, MetadataField } from '@/features/metadata/metadata.api'
 import { useMetadataEntityMetaQuery } from '@/features/metadata/metadata.query'
 import {
+  entityActionConfirm,
+  entityActionDisabledReason,
+  recordEntityActions,
+} from '@/features/records/entity-actions'
+import { useExecuteRecordActionMutation } from '@/features/records/record-actions.query'
+import {
+  recordActivityQueryKey,
+  recordByNameQueryKey,
   useSecretStatusQuery,
   useCreateRecordMutation,
   useAddRecordCommentMutation,
@@ -22,6 +31,7 @@ import {
   useUpdateSingleRecordMutation,
   useRecordActivityQuery,
 } from '@/features/records/record-form.query'
+import { recordListBaseQueryKey } from '@/features/records/record-list.query'
 import type { RecordData } from '@/features/records/records.api'
 import { secretSubmitValue } from '@/features/records/secret-input'
 import { isHiddenCollectionField, isHiddenRecordSubmitField, recordFieldLabel } from '@/features/records/system-fields'
@@ -98,6 +108,7 @@ const updateRecordMutation = useUpdateRecordMutation()
 const updateSingleRecordMutation = useUpdateSingleRecordMutation()
 const deleteRecordMutation = useDeleteRecordMutation()
 const addCommentMutation = useAddRecordCommentMutation()
+const entityActionMutation = useExecuteRecordActionMutation()
 const record = computed(() => {
   if (isSingle.value) {
     return singleRecordQuery.data.value ?? null
@@ -169,6 +180,10 @@ const recordActionError = computed(() => {
     return storeError(deleteRecordMutation.error.value, 'Studio could not delete this record.')
   }
 
+  if (entityActionMutation.error.value) {
+    return storeError(entityActionMutation.error.value, 'Studio could not run this action.')
+  }
+
   return null
 })
 const systemFields = computed(() => entityMeta.value?.['system-fields'] ?? [])
@@ -222,38 +237,54 @@ usePageCommands(computed(() => [
   { id: 'record:reset', label: 'Reset changes', disabledReason: !dirty.value ? 'No changes' : loading.value || saving.value ? 'Record is busy' : isSystem.value ? 'Read-only Record' : undefined, run: resetDraft },
   ...(!isSingle.value ? [{ id: 'record:list', label: 'Go to Entity list', run: async () => { await router.push({ name: RouteName.EntityRecords, params: { entity: props.entity } }) } }] : []),
 ]))
+const entityActions = computed(() => recordEntityActions(entityMeta.value?.actions))
 const actions = computed<PageHeaderAction[]>(() => {
-  if (isSystem.value) {
-    return []
+  const next: PageHeaderAction[] = []
+  if (!isSystem.value) {
+    next.push(
+      {
+        label: 'Reset',
+        icon: RotateCcw,
+        variant: 'secondary',
+        disabled: !dirty.value || loading.value || saving.value || entityActionMutation.isPending.value,
+        onSelect: () => { void runStudioCommand('record:reset') },
+      },
+      {
+        label: isNew.value ? 'Create record' : 'Save',
+        icon: isNew.value ? Plus : Save,
+        variant: 'primary',
+        disabled: !canSave.value || entityActionMutation.isPending.value,
+        loading: saving.value,
+        shortcut: bindings['record:save']?.shortcut,
+        onSelect: () => { void runStudioCommand('record:save') },
+      },
+    )
+    if (isRecord.value) {
+      next.push({
+        label: 'Delete',
+        icon: Trash2,
+        variant: 'secondary',
+        disabled: loading.value || saving.value || entityActionMutation.isPending.value || !record.value,
+        loading: saving.value,
+        onSelect: deleteRecord,
+      })
+    }
   }
 
-  const next: PageHeaderAction[] = [
-    {
-      label: 'Reset',
-      icon: RotateCcw,
-      variant: 'secondary',
-      disabled: !dirty.value || loading.value || saving.value,
-      onSelect: () => { void runStudioCommand('record:reset') },
-    },
-    {
-      label: isNew.value ? 'Create record' : 'Save',
-      icon: isNew.value ? Plus : Save,
-      variant: 'primary',
-      disabled: !canSave.value,
-      loading: saving.value,
-      shortcut: bindings['record:save']?.shortcut,
-      onSelect: () => { void runStudioCommand('record:save') },
-    },
-  ]
-
   if (isRecord.value) {
-    next.push({
-      label: 'Delete',
-      icon: Trash2,
-      variant: 'secondary',
-      disabled: loading.value || saving.value || !record.value,
-      loading: saving.value,
-      onSelect: deleteRecord,
+    entityActions.value.forEach((action) => {
+      if (!action) {
+        return
+      }
+      const disabledReason = entityActionDisabledReason(entityMeta.value?.key ?? '', action.name, record.value)
+      next.push({
+        label: action.label,
+        icon: entityActionIcon(action.name),
+        variant: action.danger ? 'danger' : 'secondary',
+        disabled: loading.value || saving.value || entityActionMutation.isPending.value || !record.value || Boolean(disabledReason),
+        loading: entityActionMutation.isPending.value,
+        onSelect: () => { void runEntityAction(action) },
+      })
     })
   }
 
@@ -335,6 +366,60 @@ function resetRecordActionErrors() {
   updateSingleRecordMutation.reset()
   deleteRecordMutation.reset()
   addCommentMutation.reset()
+  entityActionMutation.reset()
+}
+
+function entityActionIcon(name: string) {
+  if (name === 'cancel') {
+    return Ban
+  }
+  if (name === 'retry') {
+    return RotateCcw
+  }
+  return Play
+}
+
+async function runEntityAction(action: EntityActionDefinition) {
+  if (!isRecord.value || loading.value || saving.value || entityActionMutation.isPending.value || !record.value) {
+    return
+  }
+  if (entityActionDisabledReason(entityMeta.value?.key ?? '', action.name, record.value)) {
+    return
+  }
+
+  const confirm = entityActionConfirm(action)
+  if (confirm) {
+    const decision = await dialog.confirm({
+      title: confirm.title,
+      content: confirm.content,
+      type: confirm.type,
+      actions: [
+        { key: 'cancel', label: 'Back', variant: 'secondary' },
+        { key: 'confirm', label: action.label, variant: confirm.type === 'danger' ? 'danger' : 'primary' },
+      ],
+    })
+    if (decision !== 'confirm') {
+      return
+    }
+  }
+
+  localError.value = ''
+  resetRecordActionErrors()
+
+  const recordID = Number(currentRecordID())
+  try {
+    await entityActionMutation.mutateAsync({
+      entity: props.entity,
+      action: action.name,
+      records: [recordID],
+    })
+    await queryClient.invalidateQueries({ queryKey: recordByNameQueryKey(props.entity, props.recordName ?? '') })
+    await queryClient.invalidateQueries({ queryKey: recordActivityQueryKey(props.entity, recordID) })
+    await queryClient.invalidateQueries({ queryKey: recordListBaseQueryKey(props.entity) })
+    toast.success(`${action.label} complete`)
+  } catch {
+    // TanStack owns the mutation error for display.
+  }
 }
 
 async function addComment() {

--- a/apps/studio/ui/src/renderers/records/RecordListRenderer.vue
+++ b/apps/studio/ui/src/renderers/records/RecordListRenderer.vue
@@ -17,8 +17,10 @@ import type { DataTableRowKey, DataTableSort, DataTableState } from '@/design/ty
 import type { EntityActionDefinition, MetadataField, MetadataFilterOperator } from '@/features/metadata/metadata.api'
 import type { RecordListPolicy } from '@/features/platform/platform.api'
 import { usePlatformConfigQuery } from '@/features/platform/platform.query'
+import { useDialog } from '@/features/dialogs/use-dialog'
 import { useToast } from '@/features/toasts/use-toast'
 import { queryClient } from '@/app/query'
+import { entityActionConfirm, entityActionDisabledReason } from '@/features/records/entity-actions'
 import { recordListQueryKey } from '@/features/records/record-list.query'
 import { exportRecordsCSV, listRecords, type RecordData } from '@/features/records/records.api'
 import { useExecuteRecordActionMutation } from '@/features/records/record-actions.query'
@@ -97,6 +99,7 @@ const selectedAction = ref('')
 const exporting = ref(false)
 const importOpen = ref(false)
 const actionMutation = useExecuteRecordActionMutation()
+const dialog = useDialog()
 const toast = useToast()
 const savedFilters = useQuery({
   queryKey: computed(() => ['studio', 'saved-filters', auth.currentUser?.id, auth.sessionVersion, canonicalEntity.value]),
@@ -161,10 +164,6 @@ const selectedRecordIDs = computed(() => selectedRowKeys.value.flatMap((key) => 
   return Number.isInteger(id) && id > 0 ? [id] : []
 }))
 const selectedActionDefinition = computed(() => availableActions.value.find((action) => action.name === selectedAction.value) ?? null)
-const canRunSelectedAction = computed(() => {
-  if (!selectedActionDefinition.value || selectedRecordIDs.value.length === 0 || actionMutation.isPending.value) return false
-  return selectedActionDefinition.value.selection === 'selection' || selectedRecordIDs.value.length === 1
-})
 const recordListPolicy = computed(() => platformConfigQuery.data.value?.['record-list'] ?? null)
 const pageSizeOptions = computed(() => recordListPolicy.value?.['page-sizes'] ?? [])
 const filterableFields = computed(() => (
@@ -219,6 +218,22 @@ const recordsQuery = useInfiniteQuery({
 })
 const recordPages = computed(() => recordsQuery.data.value?.pages ?? [])
 const rows = computed<RecordData[]>(() => recordPages.value.flatMap((page) => page.data))
+const selectedRecords = computed(() => {
+  const ids = new Set(selectedRecordIDs.value)
+  return rows.value.filter((row) => {
+    if (!row) {
+      return false
+    }
+    const id = Number(row.id)
+    return Number.isInteger(id) && id > 0 && ids.has(id)
+  })
+})
+const canRunSelectedAction = computed(() => {
+  const action = selectedActionDefinition.value
+  if (!action || selectedRecordIDs.value.length === 0 || actionMutation.isPending.value) return false
+  if (!(action.selection === 'selection' || selectedRecordIDs.value.length === 1)) return false
+  return selectedRecords.value.every((record) => !entityActionDisabledReason(props.entityKey, action.name, record))
+})
 const totalRows = computed(() => recordPages.value.at(-1)?.meta.total ?? rows.value.length)
 const platformConfigError = computed(() => (
   platformConfigQuery.error.value
@@ -824,6 +839,20 @@ async function runSelectedAction() {
   const action = selectedActionDefinition.value
   const records = selectedRecordIDs.value
   if (!action || !canRunSelectedAction.value) return
+
+  const confirm = entityActionConfirm(action)
+  if (confirm) {
+    const decision = await dialog.confirm({
+      title: confirm.title,
+      content: confirm.content,
+      type: confirm.type,
+      actions: [
+        { key: 'cancel', label: 'Back', variant: 'secondary' },
+        { key: 'confirm', label: action.label, variant: confirm.type === 'danger' ? 'danger' : 'primary' },
+      ],
+    })
+    if (decision !== 'confirm') return
+  }
 
   try {
     await actionMutation.mutateAsync({ entity: props.entity, action: action.name, records })

--- a/apps/studio/ui/src/shell/types.ts
+++ b/apps/studio/ui/src/shell/types.ts
@@ -3,7 +3,7 @@ import type { Component } from 'vue'
 export type PageHeaderAction = {
   label: string
   icon?: Component
-  variant?: 'primary' | 'secondary' | 'ghost'
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger'
   disabled?: boolean
   loading?: boolean
   shortcut?: string

--- a/docs/app-model.md
+++ b/docs/app-model.md
@@ -44,7 +44,7 @@ It owns:
 - field renderers
 - collection renderer
 - saved views UI
-- jobs UI
+- Job Execution cancel and retry on Record list and form actions
 - audit log UI
 - settings UI
 - metadata API client

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,6 +137,8 @@ Generator boilerplate lives as embedded templates under `internal/generate/templ
 - `dygo job execution cancel <id-or-name>` - Cancels one queued execution; running or finished executions are not cancelled.
 - `dygo job execution retry <id-or-name> --idempotency-key <key>` - Queues a fresh manual retry for one failed execution using the old payload and the new key.
 
+Studio operators can cancel queued Job Executions and retry failed ones from Job Execution Records. `system-manager` needs Core Job access metadata applied.
+
 `job execution run` enqueues durable work; it does not run the handler inline. Start `dygo worker` to process queued executions.
 
 ## Routes

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -156,6 +156,8 @@ dygo job execution retry <id-or-name> --idempotency-key <key>
 
 `list`, `show`, `cancel`, and `retry` read the selected environment database. `cancel` only works for queued executions. `retry` only works for failed executions, copies the failed execution payload, and requires a new caller-provided idempotency key.
 
+Studio exposes the same cancel and retry operations as Job Execution Entity actions. See [Studio](#studio).
+
 All Job commands default to `--env development`.
 
 ## Job Execution Data
@@ -255,10 +257,26 @@ type EnqueueOptions struct {
 
 type JobData interface {
 	Enqueue(ctx context.Context, appName string, jobName string, payload json.RawMessage, options EnqueueOptions) (JobExecution, error)
+	CancelQueued(ctx context.Context, reference string) (JobExecution, error)
+	Retry(ctx context.Context, reference string, idempotencyKey string) (JobExecution, error)
 }
 ```
 
-App identity for SDK calls is `<app>, <job>`, not route, label, or display name. Enqueue options are intentionally small: idempotency key, priority, and `run-after`. Queue, timeout, and retry settings come from `job.yml`.
+App identity for SDK calls is `<app>, <job>`, not route, label, or display name. Enqueue options are intentionally small: idempotency key, priority, and `run-after`. Queue, timeout, and retry settings come from `job.yml`. `CancelQueued` accepts a Job Execution id or name and only succeeds for `queued` executions. `Retry` copies a `failed` execution payload into a new queued execution. Retry requires an idempotency key.
+
+## Studio
+
+Studio operators cancel queued Job Executions and retry failed ones from the Job Execution Record list and detail pages. These are Core Entity actions on `job-execution`, not a separate Jobs Space.
+
+Cancel is available while status is `queued`. Retry is available while status is `failed`. Retry queues a new Job Execution with the same payload. The retry action generates an idempotency key when the request does not include one.
+
+`system-manager` can read Job and Job Execution Records and run `cancel` and `retry`. Apply Core access metadata after upgrade:
+
+```sh
+dygo access apply --yes
+```
+
+Administrator bypasses permission checks and can also run the actions.
 
 ## Framework Notification Email
 
@@ -268,6 +286,7 @@ Core defines `core/send-notification-email`. `NotificationData.Send` queues this
 
 ```txt
 internal/jobs                - job.yml reader, validator, and shared Job metadata types
+internal/jobs/executionactions - Core Job Execution cancel and retry Entity actions
 internal/jobgen              - Job scaffold and runner wiring generator
 internal/runnergen           - shared generated project runner renderer
 internal/cli                 - Job commands
@@ -277,7 +296,7 @@ pkg/dygo/runtime              - project runner options for compiled Jobs
 
 ## Coming Soon
 
-- Studio-native Job detail, retry, and cancel screens.
+- Dedicated Studio Job and Schedule operation screens.
 - Job-backed importer foundation.
 - Retention policy for old succeeded and failed executions.
 - Optional stale-work metadata if handler-level freshness checks become repetitive.

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -35,7 +35,6 @@ These are intentionally not part of the current public CLI contract:
 - report runtime
 - custom page runtime
 - Studio schedule UI
-- Studio retry and cancel controls for Job Executions
 - production secret providers such as KMS or Vault
 
 Naming notes:

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -26,7 +26,7 @@ The current SDK exposes:
 - Record lifecycle hook types and registration
 - transactional Record reads and writes inside hooks
 - durable Job handler types and registration
-- Job enqueueing from hooks and Jobs
+- Job enqueueing, queued cancel, and failed retry from hooks, Jobs, and Entity actions
 - best-effort and strict persisted Log helpers
 - durable in-app notifications with optional email delivery
 - project runner integration types
@@ -109,7 +109,9 @@ automatically constrains every operation to that actor's owner Record. Use
 
 Entity actions receive the actor and transaction-scoped Records, Jobs, Files,
 Timeline, and Notifications services. Register one action on one Entity with
-`EntityActionRegistry.RegisterEntity`.
+`EntityActionRegistry.RegisterEntity`. Optional `confirm` text asks Studio to
+confirm before running the action. Set `danger` when the confirm dialog is
+destructive.
 
 `FileData` uploads, attaches, opens, and removes private files. `TimelineData`
 adds append-only comments and events to Core Activity.
@@ -135,6 +137,15 @@ execution, err := job.Jobs.Enqueue(ctx, "crm", "send-welcome-email", payload, dy
 ```
 
 Inside a Record hook, use `hook.Jobs.Enqueue` with the same arguments.
+
+`JobData` can also cancel a queued Job Execution or retry a failed one by numeric id or execution name:
+
+```go
+cancelled, err := call.Jobs.CancelQueued(ctx, "42")
+retried, err := call.Jobs.Retry(ctx, "42", "manual-retry:welcome:42")
+```
+
+Cancel only works while the execution is `queued`. Retry copies the failed payload into a new queued execution. Retry requires an idempotency key.
 
 Job access uses app-scoped Job identity:
 

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -4,7 +4,7 @@ Studio is dygo's main operational and builder UI.
 
 It is where operators run the business, builders configure the system, and agents help implement the system.
 
-Studio is a first-party dygo app, not a temporary admin panel. It should feel like one coherent product across records, lists, forms, saved views, audit logs, settings, and spaces. Specialized Job and Schedule operation screens are coming soon; current Job and Schedule state is stored in Core records.
+Studio is a first-party dygo app, not a temporary admin panel. It should feel like one coherent product across records, lists, forms, saved views, audit logs, settings, and spaces. Job Execution cancel and retry use the shared Record list and form Entity action controls. Specialized Job and Schedule operation screens are still coming soon.
 
 The framework repo includes the Studio app manifest at `apps/studio/app.yml` and the Vue/Vite frontend under `apps/studio/ui`.
 
@@ -35,7 +35,7 @@ Studio owns:
 - field renderers
 - collection renderer
 - saved views UI
-- jobs UI (coming soon)
+- Job Execution cancel and retry on Record list and form actions
 - audit log UI
 - settings UI
 - metadata API client

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hapyco/dygo/internal/fixtures"
 	recordhooks "github.com/hapyco/dygo/internal/hooks"
 	importsvc "github.com/hapyco/dygo/internal/imports"
+	"github.com/hapyco/dygo/internal/jobs/executionactions"
 	jobruntime "github.com/hapyco/dygo/internal/jobs/runtime"
 	"github.com/hapyco/dygo/internal/permissions"
 	"github.com/hapyco/dygo/internal/recordsecret"
@@ -125,7 +126,8 @@ func newCommandDependencies(options Options) (commandDependencies, error) {
 	if err != nil {
 		return commandDependencies{}, fmt.Errorf("configure record hooks: %w", err)
 	}
-	actionRegistry, err := entityactions.NewRegistry(options.EntityActions)
+	actionRegistrars := append([]dygo.EntityActionRegistrar{executionactions.Registrar()}, options.EntityActions...)
+	actionRegistry, err := entityactions.NewRegistry(actionRegistrars)
 	if err != nil {
 		return commandDependencies{}, fmt.Errorf("configure Entity actions: %w", err)
 	}

--- a/internal/dygodata/jobs.go
+++ b/internal/dygodata/jobs.go
@@ -3,22 +3,27 @@ package dygodata
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	jobstore "github.com/hapyco/dygo/internal/jobs/store"
 	"github.com/hapyco/dygo/pkg/dygo"
 )
 
-type jobEnqueuer interface {
+type jobOperator interface {
 	Enqueue(context.Context, string, string, json.RawMessage, jobstore.EnqueueOptions) (jobstore.Execution, error)
+	CancelQueued(context.Context, string, time.Time) (jobstore.Execution, error)
+	Retry(context.Context, string, string) (jobstore.Execution, error)
 }
 
-// JobData exposes durable Job enqueueing through the public SDK.
+// JobData exposes durable Job operations through the public SDK.
 type JobData struct {
-	store jobEnqueuer
+	store jobOperator
 }
+
+var _ dygo.JobData = JobData{}
 
 // NewJobData returns dygo JobData backed by a durable Job store.
-func NewJobData(store jobEnqueuer) JobData {
+func NewJobData(store jobOperator) JobData {
 	return JobData{store: store}
 }
 
@@ -41,6 +46,28 @@ func (d JobData) Enqueue(ctx context.Context, appName string, jobName string, pa
 	if err != nil {
 		return dygo.JobExecution{}, err
 	}
+	return d.executionFromStore(execution), nil
+}
+
+// CancelQueued marks a queued Job Execution cancelled by id or name.
+func (d JobData) CancelQueued(ctx context.Context, reference string) (dygo.JobExecution, error) {
+	execution, err := d.store.CancelQueued(ctx, reference, time.Now().UTC())
+	if err != nil {
+		return dygo.JobExecution{}, err
+	}
+	return d.executionFromStore(execution), nil
+}
+
+// Retry queues a new Job Execution from a failed execution's payload.
+func (d JobData) Retry(ctx context.Context, reference string, idempotencyKey string) (dygo.JobExecution, error) {
+	execution, err := d.store.Retry(ctx, reference, idempotencyKey)
+	if err != nil {
+		return dygo.JobExecution{}, err
+	}
+	return d.executionFromStore(execution), nil
+}
+
+func (d JobData) executionFromStore(execution jobstore.Execution) dygo.JobExecution {
 	return dygo.JobExecution{
 		ID:      execution.ID,
 		AppName: execution.AppName,
@@ -49,5 +76,5 @@ func (d JobData) Enqueue(ctx context.Context, appName string, jobName string, pa
 		Attempt: execution.Attempts,
 		Payload: execution.Payload,
 		Jobs:    d,
-	}, nil
+	}
 }

--- a/internal/dygodata/jobs_test.go
+++ b/internal/dygodata/jobs_test.go
@@ -3,6 +3,7 @@ package dygodata
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 
 func TestJobDataEnqueueMapsSDKOptions(t *testing.T) {
 	runAfter := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
-	store := &fakeJobEnqueuer{
+	store := &fakeJobOperator{
 		execution: jobstore.Execution{
 			ID:       42,
 			AppName:  "crm",
@@ -42,18 +43,78 @@ func TestJobDataEnqueueMapsSDKOptions(t *testing.T) {
 	}
 }
 
-type fakeJobEnqueuer struct {
-	appName   string
-	jobName   string
-	payload   json.RawMessage
-	options   jobstore.EnqueueOptions
-	execution jobstore.Execution
+func TestJobDataCancelQueuedUsesStore(t *testing.T) {
+	store := &fakeJobOperator{
+		execution: jobstore.Execution{ID: 7, AppName: "core", JobName: "send-notification-email", Queue: "default"},
+	}
+	execution, err := NewJobData(store).CancelQueued(context.Background(), "7")
+	if err != nil {
+		t.Fatalf("CancelQueued() error = %v, want nil", err)
+	}
+	if store.cancelReference != "7" || store.cancelAt.IsZero() {
+		t.Fatalf("CancelQueued store call = %q %v, want id 7 and a timestamp", store.cancelReference, store.cancelAt)
+	}
+	if execution.ID != 7 || execution.AppName != "core" || execution.JobName != "send-notification-email" || execution.Jobs == nil {
+		t.Fatalf("SDK execution = %+v, want cancelled execution with Jobs service", execution)
+	}
 }
 
-func (s *fakeJobEnqueuer) Enqueue(_ context.Context, appName string, jobName string, payload json.RawMessage, options jobstore.EnqueueOptions) (jobstore.Execution, error) {
+func TestJobDataRetryUsesStore(t *testing.T) {
+	store := &fakeJobOperator{
+		execution: jobstore.Execution{ID: 9, AppName: "crm", JobName: "send-email", Queue: "default"},
+	}
+	execution, err := NewJobData(store).Retry(context.Background(), "8", "manual-retry:8")
+	if err != nil {
+		t.Fatalf("Retry() error = %v, want nil", err)
+	}
+	if store.retryReference != "8" || store.retryKey != "manual-retry:8" {
+		t.Fatalf("Retry store call = %q %q, want failed id and key", store.retryReference, store.retryKey)
+	}
+	if execution.ID != 9 || execution.JobName != "send-email" || execution.Jobs == nil {
+		t.Fatalf("SDK execution = %+v, want queued retry with Jobs service", execution)
+	}
+}
+
+func TestJobDataRetryReturnsStoreError(t *testing.T) {
+	store := &fakeJobOperator{err: fmt.Errorf("job execution %q is queued; only failed executions can be retried", "8")}
+	_, err := NewJobData(store).Retry(context.Background(), "8", "retry-key")
+	if err == nil {
+		t.Fatal("Retry() error = nil, want store error")
+	}
+	if err.Error() != store.err.Error() {
+		t.Fatalf("Retry() error = %v, want store error", err)
+	}
+}
+
+type fakeJobOperator struct {
+	appName         string
+	jobName         string
+	payload         json.RawMessage
+	options         jobstore.EnqueueOptions
+	cancelReference string
+	cancelAt        time.Time
+	retryReference  string
+	retryKey        string
+	execution       jobstore.Execution
+	err             error
+}
+
+func (s *fakeJobOperator) Enqueue(_ context.Context, appName string, jobName string, payload json.RawMessage, options jobstore.EnqueueOptions) (jobstore.Execution, error) {
 	s.appName = appName
 	s.jobName = jobName
 	s.payload = payload
 	s.options = options
-	return s.execution, nil
+	return s.execution, s.err
+}
+
+func (s *fakeJobOperator) CancelQueued(_ context.Context, reference string, now time.Time) (jobstore.Execution, error) {
+	s.cancelReference = reference
+	s.cancelAt = now
+	return s.execution, s.err
+}
+
+func (s *fakeJobOperator) Retry(_ context.Context, reference string, idempotencyKey string) (jobstore.Execution, error) {
+	s.retryReference = reference
+	s.retryKey = idempotencyKey
+	return s.execution, s.err
 }

--- a/internal/dygodata/notifications_test.go
+++ b/internal/dygodata/notifications_test.go
@@ -103,3 +103,11 @@ func (f *fakeNotificationJobs) Enqueue(_ context.Context, app string, job string
 	f.enqueues++
 	return dygo.JobExecution{ID: 1}, nil
 }
+
+func (f *fakeNotificationJobs) CancelQueued(context.Context, string) (dygo.JobExecution, error) {
+	return dygo.JobExecution{}, nil
+}
+
+func (f *fakeNotificationJobs) Retry(context.Context, string, string) (dygo.JobExecution, error) {
+	return dygo.JobExecution{}, nil
+}

--- a/internal/dygodata/system_records_integration_test.go
+++ b/internal/dygodata/system_records_integration_test.go
@@ -208,7 +208,6 @@ type allowSystemTestAction struct{}
 func (allowSystemTestAction) Authorize(context.Context, dygo.PermissionRequest) error { return nil }
 
 type systemTestJobStore struct {
-	jobruntime.Store
 	failure string
 }
 
@@ -225,6 +224,27 @@ func (*systemTestJobStore) Complete(context.Context, jobstore.Execution, json.Ra
 func (s *systemTestJobStore) Fail(_ context.Context, _ jobstore.Execution, message string, _ time.Time) error {
 	s.failure = message
 	return nil
+}
+func (*systemTestJobStore) NextRunAfter(context.Context, []string, time.Time) (*time.Time, error) {
+	return nil, nil
+}
+func (*systemTestJobStore) NextScheduleRunAt(context.Context, []string, time.Time) (*time.Time, error) {
+	return nil, nil
+}
+func (*systemTestJobStore) FailFinal(context.Context, jobstore.Execution, string, time.Time) error {
+	return nil
+}
+func (*systemTestJobStore) ExpireClaim(context.Context, jobstore.Execution, time.Time) error {
+	return nil
+}
+func (*systemTestJobStore) Enqueue(context.Context, string, string, json.RawMessage, jobstore.EnqueueOptions) (jobstore.Execution, error) {
+	return jobstore.Execution{}, nil
+}
+func (*systemTestJobStore) CancelQueued(context.Context, string, time.Time) (jobstore.Execution, error) {
+	return jobstore.Execution{}, nil
+}
+func (*systemTestJobStore) Retry(context.Context, string, string) (jobstore.Execution, error) {
+	return jobstore.Execution{}, nil
 }
 
 func testSystemUpsertConcurrentConflict(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {

--- a/internal/frameworkapp/bundled/core/access/job-execution.access.yml
+++ b/internal/frameworkapp/bundled/core/access/job-execution.access.yml
@@ -1,0 +1,3 @@
+policy:
+  - role: system-manager
+    can: [read, export, print, cancel, retry]

--- a/internal/frameworkapp/bundled/core/access/job.access.yml
+++ b/internal/frameworkapp/bundled/core/access/job.access.yml
@@ -1,0 +1,3 @@
+policy:
+  - role: system-manager
+    can: [read, export, print]

--- a/internal/jobs/executionactions/actions.go
+++ b/internal/jobs/executionactions/actions.go
@@ -1,0 +1,110 @@
+package executionactions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+const (
+	coreApp      = "core"
+	jobExecution = "job-execution"
+	cancelAction = "cancel"
+	retryAction  = "retry"
+)
+
+type retryInput struct {
+	IdempotencyKey string `json:"idempotency-key"`
+}
+
+// Registrar registers Core Job Execution cancel and retry Entity actions.
+func Registrar() dygo.EntityActionRegistrar {
+	return func(registry dygo.EntityActionRegistry) error {
+		if err := registry.RegisterEntity(coreApp, jobExecution, dygo.EntityActionDefinition{
+			Name:      cancelAction,
+			Label:     "Cancel",
+			Selection: dygo.ActionSelectionRecord,
+			Confirm:   "This queued Job Execution will not run.",
+			Danger:    true,
+		}, cancelQueued); err != nil {
+			return err
+		}
+		return registry.RegisterEntity(coreApp, jobExecution, dygo.EntityActionDefinition{
+			Name:      retryAction,
+			Label:     "Retry",
+			Selection: dygo.ActionSelectionRecord,
+			Confirm:   "dygo will queue a new Job Execution with the same payload.",
+		}, retryFailed)
+	}
+}
+
+func cancelQueued(ctx context.Context, call dygo.EntityActionCall) (any, error) {
+	if call.Jobs == nil {
+		return nil, dygo.ActionError{Code: "internal_error", Message: "Job service is unavailable"}
+	}
+	execution, err := call.Jobs.CancelQueued(ctx, executionReference(call))
+	if err != nil {
+		return nil, mapJobStoreError(err)
+	}
+	return executionResult(execution, "cancelled"), nil
+}
+
+func retryFailed(ctx context.Context, call dygo.EntityActionCall) (any, error) {
+	if call.Jobs == nil {
+		return nil, dygo.ActionError{Code: "internal_error", Message: "Job service is unavailable"}
+	}
+	var input retryInput
+	if len(call.Input) > 0 {
+		if err := json.Unmarshal(call.Input, &input); err != nil {
+			return nil, dygo.ActionError{Code: "invalid_request", Message: "retry input must be valid JSON"}
+		}
+	}
+	idempotencyKey := strings.TrimSpace(input.IdempotencyKey)
+	if idempotencyKey == "" {
+		idempotencyKey = fmt.Sprintf("manual-retry:%s:%d", executionReference(call), time.Now().UTC().UnixNano())
+	}
+	execution, err := call.Jobs.Retry(ctx, executionReference(call), idempotencyKey)
+	if err != nil {
+		return nil, mapJobStoreError(err)
+	}
+	return executionResult(execution, "queued"), nil
+}
+
+func executionReference(call dygo.EntityActionCall) string {
+	if len(call.RecordIDs) == 0 {
+		return ""
+	}
+	return strconv.FormatInt(call.RecordIDs[0], 10)
+}
+
+func executionResult(execution dygo.JobExecution, status string) map[string]any {
+	return map[string]any{
+		"id":       execution.ID,
+		"app-name": execution.AppName,
+		"job-name": execution.JobName,
+		"queue":    execution.Queue,
+		"status":   status,
+	}
+}
+
+func mapJobStoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var actionErr dygo.ActionError
+	if errors.As(err, &actionErr) {
+		return actionErr
+	}
+	message := err.Error()
+	code := "invalid_request"
+	if strings.Contains(message, "was not found") {
+		code = "not_found"
+	}
+	return dygo.ActionError{Code: code, Message: message}
+}

--- a/internal/jobs/executionactions/actions.go
+++ b/internal/jobs/executionactions/actions.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hapyco/dygo/pkg/dygo"
 )
@@ -67,7 +65,7 @@ func retryFailed(ctx context.Context, call dygo.EntityActionCall) (any, error) {
 	}
 	idempotencyKey := strings.TrimSpace(input.IdempotencyKey)
 	if idempotencyKey == "" {
-		idempotencyKey = fmt.Sprintf("manual-retry:%s:%d", executionReference(call), time.Now().UTC().UnixNano())
+		idempotencyKey = "manual-retry:" + executionReference(call)
 	}
 	execution, err := call.Jobs.Retry(ctx, executionReference(call), idempotencyKey)
 	if err != nil {
@@ -102,9 +100,14 @@ func mapJobStoreError(err error) error {
 		return actionErr
 	}
 	message := err.Error()
-	code := "invalid_request"
 	if strings.Contains(message, "was not found") {
-		code = "not_found"
+		return dygo.ActionError{Code: "not_found", Message: "Job Execution was not found"}
 	}
-	return dygo.ActionError{Code: code, Message: message}
+	if strings.Contains(message, "only queued executions can be cancelled") ||
+		strings.Contains(message, "only failed executions can be retried") ||
+		strings.Contains(message, "id or name is required") ||
+		strings.Contains(message, "requires an idempotency key") {
+		return dygo.ActionError{Code: "invalid_request", Message: message}
+	}
+	return dygo.ActionError{Code: "internal_error", Message: "Job Execution action failed"}
 }

--- a/internal/jobs/executionactions/actions_test.go
+++ b/internal/jobs/executionactions/actions_test.go
@@ -62,7 +62,7 @@ func TestRetryFailedGeneratesIdempotencyKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("retryFailed() error = %v, want nil", err)
 	}
-	if jobs.retried != "19" || !strings.HasPrefix(jobs.retryKey, "manual-retry:19:") {
+	if jobs.retried != "19" || jobs.retryKey != "manual-retry:19" {
 		t.Fatalf("Retry call = %q %q, want generated key for 19", jobs.retried, jobs.retryKey)
 	}
 	got, _ := result.(map[string]any)
@@ -96,6 +96,12 @@ func TestRetryFailedMapsMissingExecution(t *testing.T) {
 	jobs := &fakeJobData{err: fmt.Errorf(`job execution "19" was not found`)}
 	_, err := retryFailed(context.Background(), dygo.EntityActionCall{RecordIDs: []int64{19}, Jobs: jobs})
 	assertActionError(t, err, "not_found", "was not found")
+}
+
+func TestRetryFailedHidesUnexpectedStoreError(t *testing.T) {
+	jobs := &fakeJobData{err: fmt.Errorf("load job execution: pq: permission denied for relation job_execution")}
+	_, err := retryFailed(context.Background(), dygo.EntityActionCall{RecordIDs: []int64{19}, Jobs: jobs})
+	assertActionError(t, err, "internal_error", "Job Execution action failed")
 }
 
 func assertActionError(t *testing.T, err error, code string, contains string) {

--- a/internal/jobs/executionactions/actions_test.go
+++ b/internal/jobs/executionactions/actions_test.go
@@ -1,0 +1,136 @@
+package executionactions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hapyco/dygo/internal/actions"
+	"github.com/hapyco/dygo/pkg/dygo"
+)
+
+func TestRegistrarRegistersCancelAndRetry(t *testing.T) {
+	registry, err := actions.NewRegistry([]dygo.EntityActionRegistrar{Registrar()})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v, want nil", err)
+	}
+	definitions := registry.Definitions("core", "job-execution")
+	if len(definitions) != 2 {
+		t.Fatalf("Definitions() = %+v, want cancel and retry", definitions)
+	}
+	cancel := definitions[0]
+	if cancel.Name != "cancel" || cancel.Label != "Cancel" || cancel.Selection != dygo.ActionSelectionRecord || !cancel.Danger || cancel.Confirm == "" {
+		t.Fatalf("cancel definition = %+v, want record cancel with confirm", cancel)
+	}
+	retry := definitions[1]
+	if retry.Name != "retry" || retry.Label != "Retry" || retry.Selection != dygo.ActionSelectionRecord || retry.Danger || retry.Confirm == "" {
+		t.Fatalf("retry definition = %+v, want record retry with confirm", retry)
+	}
+}
+
+func TestCancelQueuedRejectsNonQueuedExecution(t *testing.T) {
+	jobs := &fakeJobData{err: fmt.Errorf(`job execution "12" is running; only queued executions can be cancelled`)}
+	_, err := cancelQueued(context.Background(), dygo.EntityActionCall{RecordIDs: []int64{12}, Jobs: jobs})
+	assertActionError(t, err, "invalid_request", "only queued executions can be cancelled")
+	if jobs.cancelled != "12" {
+		t.Fatalf("CancelQueued reference = %q, want 12", jobs.cancelled)
+	}
+}
+
+func TestCancelQueuedReturnsCancelledExecution(t *testing.T) {
+	jobs := &fakeJobData{execution: dygo.JobExecution{ID: 12, AppName: "core", JobName: "send-notification-email", Queue: "default"}}
+	result, err := cancelQueued(context.Background(), dygo.EntityActionCall{RecordIDs: []int64{12}, Jobs: jobs})
+	if err != nil {
+		t.Fatalf("cancelQueued() error = %v, want nil", err)
+	}
+	got, _ := result.(map[string]any)
+	if got["id"] != int64(12) || got["status"] != "cancelled" || got["job-name"] != "send-notification-email" {
+		t.Fatalf("cancelQueued() = %#v, want cancelled execution", result)
+	}
+}
+
+func TestRetryFailedGeneratesIdempotencyKey(t *testing.T) {
+	jobs := &fakeJobData{execution: dygo.JobExecution{ID: 20, AppName: "crm", JobName: "send-email", Queue: "default"}}
+	result, err := retryFailed(context.Background(), dygo.EntityActionCall{
+		RecordIDs: []int64{19},
+		Input:     json.RawMessage(`{}`),
+		Jobs:      jobs,
+	})
+	if err != nil {
+		t.Fatalf("retryFailed() error = %v, want nil", err)
+	}
+	if jobs.retried != "19" || !strings.HasPrefix(jobs.retryKey, "manual-retry:19:") {
+		t.Fatalf("Retry call = %q %q, want generated key for 19", jobs.retried, jobs.retryKey)
+	}
+	got, _ := result.(map[string]any)
+	if got["id"] != int64(20) || got["status"] != "queued" {
+		t.Fatalf("retryFailed() = %#v, want queued retry", result)
+	}
+}
+
+func TestRetryFailedUsesCallerIdempotencyKey(t *testing.T) {
+	jobs := &fakeJobData{execution: dygo.JobExecution{ID: 21, AppName: "crm", JobName: "send-email"}}
+	_, err := retryFailed(context.Background(), dygo.EntityActionCall{
+		RecordIDs: []int64{19},
+		Input:     json.RawMessage(`{"idempotency-key":"studio-retry:19"}`),
+		Jobs:      jobs,
+	})
+	if err != nil {
+		t.Fatalf("retryFailed() error = %v, want nil", err)
+	}
+	if jobs.retryKey != "studio-retry:19" {
+		t.Fatalf("Retry key = %q, want caller key", jobs.retryKey)
+	}
+}
+
+func TestRetryFailedRejectsNonFailedExecution(t *testing.T) {
+	jobs := &fakeJobData{err: fmt.Errorf(`job execution "19" is succeeded; only failed executions can be retried`)}
+	_, err := retryFailed(context.Background(), dygo.EntityActionCall{RecordIDs: []int64{19}, Jobs: jobs})
+	assertActionError(t, err, "invalid_request", "only failed executions can be retried")
+}
+
+func TestRetryFailedMapsMissingExecution(t *testing.T) {
+	jobs := &fakeJobData{err: fmt.Errorf(`job execution "19" was not found`)}
+	_, err := retryFailed(context.Background(), dygo.EntityActionCall{RecordIDs: []int64{19}, Jobs: jobs})
+	assertActionError(t, err, "not_found", "was not found")
+}
+
+func assertActionError(t *testing.T, err error, code string, contains string) {
+	t.Helper()
+	var actionErr dygo.ActionError
+	if err == nil {
+		t.Fatalf("error = nil, want ActionError %s", code)
+	}
+	if !errors.As(err, &actionErr) {
+		t.Fatalf("error = %v, want ActionError", err)
+	}
+	if actionErr.Code != code || !strings.Contains(actionErr.Message, contains) {
+		t.Fatalf("ActionError = %+v, want code %s containing %q", actionErr, code, contains)
+	}
+}
+
+type fakeJobData struct {
+	cancelled string
+	retried   string
+	retryKey  string
+	execution dygo.JobExecution
+	err       error
+}
+
+func (d *fakeJobData) Enqueue(context.Context, string, string, json.RawMessage, dygo.EnqueueOptions) (dygo.JobExecution, error) {
+	return dygo.JobExecution{}, fmt.Errorf("enqueue is not used")
+}
+
+func (d *fakeJobData) CancelQueued(_ context.Context, reference string) (dygo.JobExecution, error) {
+	d.cancelled = reference
+	return d.execution, d.err
+}
+
+func (d *fakeJobData) Retry(_ context.Context, reference string, idempotencyKey string) (dygo.JobExecution, error) {
+	d.retried = reference
+	d.retryKey = idempotencyKey
+	return d.execution, d.err
+}

--- a/internal/jobs/runtime/runtime.go
+++ b/internal/jobs/runtime/runtime.go
@@ -58,6 +58,8 @@ type Store interface {
 	FailFinal(context.Context, jobstore.Execution, string, time.Time) error
 	ExpireClaim(context.Context, jobstore.Execution, time.Time) error
 	Enqueue(context.Context, string, string, json.RawMessage, jobstore.EnqueueOptions) (jobstore.Execution, error)
+	CancelQueued(context.Context, string, time.Time) (jobstore.Execution, error)
+	Retry(context.Context, string, string) (jobstore.Execution, error)
 }
 
 // NotificationListener waits for PostgreSQL queue notifications.

--- a/internal/jobs/runtime/runtime_test.go
+++ b/internal/jobs/runtime/runtime_test.go
@@ -676,6 +676,14 @@ func (s *fakeStore) Enqueue(context.Context, string, string, json.RawMessage, jo
 	return jobstore.Execution{}, nil
 }
 
+func (s *fakeStore) CancelQueued(context.Context, string, time.Time) (jobstore.Execution, error) {
+	return jobstore.Execution{}, nil
+}
+
+func (s *fakeStore) Retry(context.Context, string, string) (jobstore.Execution, error) {
+	return jobstore.Execution{}, nil
+}
+
 func ptrTime(value time.Time) *time.Time {
 	return &value
 }

--- a/pkg/dygo/actions.go
+++ b/pkg/dygo/actions.go
@@ -19,6 +19,8 @@ type EntityActionDefinition struct {
 	Name      string          `json:"name"`
 	Label     string          `json:"label"`
 	Selection ActionSelection `json:"selection"`
+	Confirm   string          `json:"confirm,omitempty"`
+	Danger    bool            `json:"danger,omitempty"`
 }
 
 // EntityActionCall contains one authorized, transactional action invocation.

--- a/pkg/dygo/jobs.go
+++ b/pkg/dygo/jobs.go
@@ -44,4 +44,6 @@ type EnqueueOptions struct {
 // JobData gives app code access to durable Jobs.
 type JobData interface {
 	Enqueue(ctx context.Context, appName string, jobName string, payload json.RawMessage, options EnqueueOptions) (JobExecution, error)
+	CancelQueued(ctx context.Context, reference string) (JobExecution, error)
+	Retry(ctx context.Context, reference string, idempotencyKey string) (JobExecution, error)
 }


### PR DESCRIPTION
## Summary

- Add Core `job-execution` actions `cancel` (queued only) and `retry` (failed only), backed by `JobData.CancelQueued` / `JobData.Retry`.
- Surface those actions in Studio on the Job Execution list (Action + Run) and record page, with confirm dialogs and status gating.
- Grant `system-manager` cancel/retry on Job Execution. Apply with `dygo access apply --yes` after upgrade.

Closes #217
Closes #218

## Test plan

- [ ] Queued Job Execution: Cancel is enabled, Retry is disabled; Cancel removes it from the queue
- [ ] Failed Job Execution: Retry is enabled, Cancel is disabled; Retry queues a new execution with the same payload
- [ ] Running / succeeded executions cannot be cancelled or retried
- [ ] List Action dropdown + Run and record-page buttons both work after confirmation
- [ ] Non-admin `system-manager` can cancel/retry; other roles cannot

Made with [Cursor](https://cursor.com)