### PR TITLE
feat(studio): add multi-tab navigation

### DIFF
--- a/apps/studio/ui/package.json
+++ b/apps/studio/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "test": "node --test src/stores/*.test.ts src/renderers/records/*.test.ts src/features/*/*.test.ts",
+    "test": "node --test src/stores/*.test.ts src/renderers/records/*.test.ts src/features/*/*.test.ts src/router/*.test.ts",
     "build": "vue-tsc --noEmit && vite build",
     "build:embed": "vue-tsc --noEmit && vite build --outDir ../../../internal/studio/bundled --emptyOutDir false",
     "preview": "vite preview --host 127.0.0.1"

--- a/apps/studio/ui/src/app/App.vue
+++ b/apps/studio/ui/src/app/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onErrorCaptured, onUnmounted } from 'vue'
+import { computed, defineAsyncComponent, onErrorCaptured, onUnmounted, watch } from 'vue'
 import { RouterView, useRoute, useRouter } from 'vue-router'
 import { LockKeyhole, RefreshCw, TriangleAlert } from '@lucide/vue'
 
@@ -11,16 +11,18 @@ import ToastHost from '@/features/toasts/ToastHost.vue'
 import { useToast } from '@/features/toasts/use-toast'
 import { setAPIDialogHandler, setAPIToastHandler } from '@/features/api/client'
 import { iconForEntity } from '@/features/metadata/entity-icons'
-import { routeParam, RouteName } from '@/router/routes'
+import { studioPathIsEntity } from '@/router/current'
+import { RouteName } from '@/router/routes'
 import { installBootRoutes } from '@/router'
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
 import Shell from '@/shell/Shell.vue'
 import type { ShellNavItem } from '@/shell/types'
 import { useAuthStore } from '@/stores/auth.store'
 import { useBootStore } from '@/stores/boot.store'
-import { humanizeEntity } from '@/stores/metadata.identity'
+import { findEntityByRouteSlug, humanizeEntity } from '@/stores/metadata.identity'
 import { useNavigationStore } from '@/stores/navigation.store'
 import { storeError } from '@/stores/status'
+import { tabLabelForRoute } from '@/features/tabs/tabs'
 
 const route = useRoute()
 const router = useRouter()
@@ -51,15 +53,6 @@ onUnmounted(() => {
 
 const usesShell = computed(() => !route.meta.public)
 const publicRouteViewKey = computed(() => `${route.fullPath}:${navigationStore.routeReloadVersion}`)
-const shellRouteViewKey = computed(() => `${route.path}:${navigationStore.routeReloadVersion}`)
-const currentEntity = computed(() => {
-  const value = route.params.entity
-  if (typeof value !== 'string' && !Array.isArray(value)) {
-    return ''
-  }
-
-  return routeParam(value)
-})
 const metadataEntitiesQuery = useMetadataEntitiesQuery({
   enabled: computed(() => (
     usesShell.value
@@ -101,16 +94,31 @@ async function retryBoot() {
 }
 
 function isEntityRoute(entity: string): boolean {
-  if (
-    route.name !== RouteName.EntityRecords
-    && route.name !== RouteName.RecordNew
-    && route.name !== RouteName.RecordDetail
-  ) {
-    return false
-  }
-
-  return currentEntity.value === entity
+  return studioPathIsEntity(route.path, entity)
 }
+
+watch(
+  () => [route.path, route.fullPath, String(route.name ?? ''), bootStore.status, authStore.currentUser?.id ?? null, metadataEntities.value] as const,
+  (_current, previous) => {
+    if (!usesShell.value || bootStore.status !== 'ready' || !authStore.currentUser) return
+    if (route.name === RouteName.Home && typeof bootStore.defaults?.home === 'string' && bootStore.defaults.home !== '/') return
+    const previousPath = previous ? previous[0] : ''
+    navigationStore.syncTab({
+      path: route.path,
+      fullPath: route.fullPath,
+      label: tabLabelForRoute({
+        name: route.name,
+        path: route.path,
+        fullPath: route.fullPath,
+        params: route.params,
+      }, (slug) => {
+        const entity = findEntityByRouteSlug(metadataEntities.value, slug)
+        return entity?.label || humanizeEntity(slug)
+      }),
+    }, previousPath)
+  },
+  { immediate: true },
+)
 
 </script>
 
@@ -167,7 +175,11 @@ function isEntityRoute(entity: string): boolean {
         </Button>
       </section>
 
-      <RouterView v-else :key="shellRouteViewKey" />
+      <RouterView v-else v-slot="{ Component }">
+        <KeepAlive :max="Math.max(navigationStore.openTabs.length, 1)">
+          <component :is="Component" :key="navigationStore.tabCacheKey(route.path)" />
+        </KeepAlive>
+      </RouterView>
     </Shell>
     <DebugBar v-if="DebugBar" />
   </div>

--- a/apps/studio/ui/src/features/commands/context.ts
+++ b/apps/studio/ui/src/features/commands/context.ts
@@ -1,4 +1,4 @@
-import { computed, onScopeDispose, shallowRef, watch, type ComputedRef } from 'vue'
+import { computed, getCurrentInstance, onActivated, onDeactivated, onScopeDispose, shallowRef, watch, type ComputedRef } from 'vue'
 import { commandBinding, executeCommand, type StudioCommand } from './shortcuts.ts'
 
 export type PageCommand = StudioCommand
@@ -14,9 +14,21 @@ export function runStudioCommand(id: string) {
 
 export function usePageCommands(commands: ComputedRef<PageCommand[]>) {
   const owner = Symbol('page commands')
-  pages.value = [...pages.value, { owner, commands: [] }]
-  watch(commands, value => { pages.value = pages.value.map(page => page.owner === owner ? { owner, commands: value.map(commandBinding) } : page) }, { immediate: true })
-  onScopeDispose(() => {
+  function snapshot() { return commands.value.map(commandBinding) }
+  function register() {
+    pages.value = [...pages.value.filter(page => page.owner !== owner), { owner, commands: snapshot() }]
+  }
+  function unregister() {
     pages.value = pages.value.filter(page => page.owner !== owner)
-  })
+  }
+  register()
+  watch(commands, () => {
+    if (!pages.value.some(page => page.owner === owner)) return
+    pages.value = pages.value.map(page => page.owner === owner ? { owner, commands: snapshot() } : page)
+  }, { immediate: true })
+  if (getCurrentInstance()) {
+    onActivated(register)
+    onDeactivated(unregister)
+  }
+  onScopeDispose(unregister)
 }

--- a/apps/studio/ui/src/features/pages/PageHost.vue
+++ b/apps/studio/ui/src/features/pages/PageHost.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
 
 import { ErrorState, Spinner } from '@/design'
 import { storeError } from '@/stores/status'
+import { useNavigationStore } from '@/stores/navigation.store'
 import { pageRenderer } from './page-renderers'
 import { usePageQuery } from './pages.query'
 
@@ -18,6 +20,12 @@ const renderer = computed(() => page.value ? pageRenderer(page.value.renderer) :
 const error = computed(() => pageQuery.error.value
   ? storeError(pageQuery.error.value, 'Studio could not load this Page.')
   : null)
+const route = useRoute()
+const navigation = useNavigationStore()
+const sheetPath = route.path
+watch(() => page.value?.label, label => {
+  if (label) navigation.setTabLabel(sheetPath, label)
+})
 </script>
 
 <template>

--- a/apps/studio/ui/src/features/pinned/PinnedNav.vue
+++ b/apps/studio/ui/src/features/pinned/PinnedNav.vue
@@ -5,6 +5,7 @@ import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka
 import { RouterLink, useRoute } from 'vue-router'
 
 import { useMetadataEntitiesQuery } from '@/features/metadata/metadata.query'
+import { studioPinIsCurrent } from '@/router/current'
 import type { PinnedItem } from './pinned'
 import { useBootStore } from '@/stores/boot.store'
 import { useNavigationStore } from '@/stores/navigation.store'
@@ -96,7 +97,7 @@ function followPin(event: MouseEvent, path: string | null) {
       <PopoverContent class="pinned-nav__popover" side="right" align="start" :side-offset="8">
         <p class="pinned-nav__popover-title">Pinned</p>
         <div class="pinned-nav__popover-list">
-          <div v-for="entry in items" :key="entry.item.path" class="pinned-nav__item" :class="{ 'pinned-nav__item--current': entry.path === route.path }">
+          <div v-for="entry in items" :key="entry.item.path" class="pinned-nav__item" :class="{ 'pinned-nav__item--current': studioPinIsCurrent(entry.item.type, entry.path, route.path) }">
             <button class="pinned-nav__remove" type="button" :aria-label="`Unpin ${entry.item.label}`" @click="navigation.unpin(entry.item)">
               <Pin :size="16" :stroke-width="1.8" aria-hidden="true" />
             </button>
@@ -120,7 +121,7 @@ function followPin(event: MouseEvent, path: string | null) {
         v-for="(entry, index) in visibleItems"
         :key="`${entry.item.type}:${entry.item.app}:${entry.item.entity ?? entry.item.page}:${entry.item.record ?? ''}`"
         class="pinned-nav__item"
-        :class="{ 'pinned-nav__item--current': entry.path === route.path, 'pinned-nav__item--grabbed': grabbed === index }"
+        :class="{ 'pinned-nav__item--current': studioPinIsCurrent(entry.item.type, entry.path, route.path), 'pinned-nav__item--grabbed': grabbed === index }"
         :data-pinned-index="index"
         draggable="true"
         tabindex="0"

--- a/apps/studio/ui/src/features/records/use-draft-guard.ts
+++ b/apps/studio/ui/src/features/records/use-draft-guard.ts
@@ -1,14 +1,18 @@
-import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router'
+import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute } from 'vue-router'
 import { useDialog } from '@/features/dialogs/use-dialog'
+import { useNavigationStore } from '@/stores/navigation.store'
 import { draftProtection } from './draft-protection'
 
 export function useDraftGuard(dirty: () => boolean, saving: () => boolean) {
   const dialog = useDialog()
+  const route = useRoute()
+  const navigation = useNavigationStore()
+  const sheetPath = route.path
   const confirmDiscard = draftProtection(dirty, saving, () => dialog.confirm({
       title: 'Discard changes?', content: 'Unsaved changes will be lost.', type: 'warning',
       actions: [{ key: 'cancel', label: 'Keep editing', variant: 'secondary' }, { key: 'discard', label: 'Discard changes', variant: 'danger' }],
     }).then(result => result === 'discard'))
-  onBeforeRouteLeave(confirmDiscard)
-  onBeforeRouteUpdate((to, from) => to.path === from.path ? true : confirmDiscard())
+  onBeforeRouteLeave(() => navigation.openTabs.some(tab => tab.path === sheetPath) ? true : confirmDiscard())
+  onBeforeRouteUpdate((to, from) => to.path === from.path || navigation.openTabs.some(tab => tab.path === sheetPath) ? true : confirmDiscard())
   return confirmDiscard
 }

--- a/apps/studio/ui/src/features/tabs/PageTabs.vue
+++ b/apps/studio/ui/src/features/tabs/PageTabs.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { X } from '@lucide/vue'
+
+import { studioPathsEqual } from '@/router/current'
+import { useNavigationStore } from '@/stores/navigation.store'
+import { useCloseTab } from './use-close-tab'
+
+const route = useRoute()
+const router = useRouter()
+const navigation = useNavigationStore()
+const closeTab = useCloseTab()
+const tabs = computed(() => navigation.openTabs)
+const canClose = computed(() => tabs.value.length > 1)
+
+async function activate(path: string) {
+  const tab = tabs.value.find(item => item.path === path)
+  if (!tab || studioPathsEqual(tab.path, route.path)) return
+  await router.push(tab.fullPath)
+}
+
+function tabIsActive(path: string) {
+  return studioPathsEqual(path, route.path)
+}
+
+function onTabKeydown(event: KeyboardEvent, path: string) {
+  if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+    event.preventDefault()
+    const tab = navigation.cycleTab(path, event.key === 'ArrowRight' ? 1 : -1)
+    if (!tab) return
+    const target = document.getElementById(tabId(tab.path))
+    target?.focus()
+    void activate(tab.path)
+  } else if ((event.key === 'Delete' || event.key === 'Backspace') && canClose.value) {
+    event.preventDefault()
+    void closeTab(path)
+  }
+}
+
+function tabId(path: string) {
+  return `studio-tab-${encodeURIComponent(path)}`
+}
+</script>
+
+<template>
+  <div v-if="tabs.length > 0" class="page-tabs" role="tablist" aria-label="Open pages">
+    <div
+      v-for="tab in tabs"
+      :key="tab.path"
+      class="page-tabs__item"
+      :class="{ 'page-tabs__item--active': tabIsActive(tab.path), 'page-tabs__item--dirty': navigation.dirtyTabPaths.includes(tab.path) }"
+    >
+      <button
+        :id="tabId(tab.path)"
+        class="page-tabs__tab"
+        :class="{ 'page-tabs__tab--active': tabIsActive(tab.path) }"
+        type="button"
+        role="tab"
+        :aria-selected="tabIsActive(tab.path)"
+        :tabindex="tabIsActive(tab.path) ? 0 : -1"
+        :title="tab.label"
+        @click="activate(tab.path)"
+        @keydown="onTabKeydown($event, tab.path)"
+        @auxclick.prevent="canClose && $event.button === 1 && closeTab(tab.path)"
+      >
+        <span class="page-tabs__label">{{ tab.label }}</span>
+        <span v-if="navigation.dirtyTabPaths.includes(tab.path)" class="page-tabs__dirty" aria-label="Unsaved changes" />
+      </button>
+      <button
+        v-if="canClose"
+        class="page-tabs__close"
+        type="button"
+        :aria-label="`Close ${tab.label}`"
+        @click.stop="closeTab(tab.path)"
+      >
+        <X :size="12" :stroke-width="2.2" aria-hidden="true" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.page-tabs {
+  display: flex;
+  min-width: 0;
+  align-items: end;
+  gap: 4px;
+  overflow-x: auto;
+  padding: 8px 2px 0;
+}
+
+.page-tabs__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  min-width: 88px;
+  max-width: 220px;
+  min-height: 32px;
+  gap: 4px;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  border-radius: var(--studio-radius-sheet) var(--studio-radius-sheet) 0 0;
+  background: transparent;
+  color: var(--studio-text-muted);
+  padding: 0 6px 0 12px;
+}
+
+.page-tabs__item:hover {
+  background: var(--studio-surface-raised);
+  color: var(--studio-text);
+}
+
+.page-tabs__item--active {
+  background: var(--studio-surface);
+  border-color: var(--studio-border);
+  color: var(--studio-text);
+  box-shadow: 0 1px 0 var(--studio-surface);
+}
+
+.page-tabs__tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  min-height: 32px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.page-tabs__tab:focus-visible,
+.page-tabs__close:focus-visible {
+  outline: 2px solid var(--studio-focus);
+  outline-offset: -2px;
+}
+
+.page-tabs__label {
+  display: block;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.page-tabs__dirty {
+  content: '';
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--studio-warning);
+  vertical-align: middle;
+}
+
+.page-tabs__close {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--studio-radius-control);
+  background: transparent;
+  color: inherit;
+}
+
+.page-tabs__close:hover {
+  background: var(--studio-surface-raised);
+  color: var(--studio-text);
+}
+
+@media (max-width: 720px) {
+  .page-tabs {
+    padding: 6px 0 0;
+  }
+
+  .page-tabs__tab {
+    min-width: 72px;
+  }
+}
+</style>

--- a/apps/studio/ui/src/features/tabs/sheet-active.ts
+++ b/apps/studio/ui/src/features/tabs/sheet-active.ts
@@ -1,0 +1,10 @@
+import { getCurrentInstance, onActivated, onDeactivated, ref, type Ref } from 'vue'
+
+export function useSheetActive(): Ref<boolean> {
+  const active = ref(true)
+  if (getCurrentInstance()) {
+    onActivated(() => { active.value = true })
+    onDeactivated(() => { active.value = false })
+  }
+  return active
+}

--- a/apps/studio/ui/src/features/tabs/tabs.test.ts
+++ b/apps/studio/ui/src/features/tabs/tabs.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { RouteName } from '../../router/routes.ts'
+import {
+  closeStudioTab,
+  cycleStudioTab,
+  morphStudioTab,
+  normalizeStudioTabs,
+  shouldMorphNewRecordTab,
+  tabCacheKey,
+  tabLabelForRoute,
+  upsertStudioTab,
+} from './tabs.ts'
+
+const home = { path: '/', fullPath: '/', label: 'Home' }
+const customers = { path: '/customers', fullPath: '/customers?status=open', label: 'Customers' }
+const draft = { path: '/customers/new', fullPath: '/customers/new', label: 'New Customer' }
+const saved = { path: '/customers/CUS-1', fullPath: '/customers/CUS-1', label: 'Customer / CUS-1' }
+
+test('normalizes open tabs and drops duplicate paths', () => {
+  const tabs = normalizeStudioTabs([
+    customers,
+    { path: '/customers', fullPath: '/customers', label: 'Old' },
+    { path: 'customers', fullPath: '/customers', label: 'Bad' },
+    home,
+  ])
+  assert.equal(tabs.length, 2)
+  assert.equal(tabs[0]?.label, 'Customers')
+  assert.equal(tabs[0]?.fullPath, '/customers?status=open')
+})
+
+test('upsert updates query state without changing tab order', () => {
+  const tabs = upsertStudioTab([home, customers], { ...customers, fullPath: '/customers?q=acme', label: 'Customers' })
+  assert.deepEqual(tabs.map(tab => tab.path), ['/', '/customers'])
+  assert.equal(tabs[1]?.fullPath, '/customers?q=acme')
+})
+
+test('creating a Record replaces the New Record tab in place', () => {
+  assert.equal(shouldMorphNewRecordTab(draft.path, saved.path), true)
+  assert.equal(shouldMorphNewRecordTab(customers.path, saved.path), false)
+  const tabs = morphStudioTab([home, draft, customers], draft.path, saved)
+  assert.deepEqual(tabs.map(tab => tab.path), ['/', '/customers/CUS-1', '/customers'])
+})
+
+test('closing the active tab activates a neighbor and keeps the last tab', () => {
+  const closed = closeStudioTab([home, customers, saved], customers.path, customers.path)
+  assert.deepEqual(closed.tabs.map(tab => tab.path), ['/', '/customers/CUS-1'])
+  assert.equal(closed.activate?.path, '/customers/CUS-1')
+  const last = closeStudioTab([home], home.path, home.path)
+  assert.equal(last.closed, false)
+  assert.equal(last.tabs.length, 1)
+  assert.equal(last.activate, null)
+})
+
+test('cycle wraps around open tabs', () => {
+  const tabs = [home, customers, saved]
+  assert.equal(cycleStudioTab(tabs, customers.path, 1)?.path, saved.path)
+  assert.equal(cycleStudioTab(tabs, home.path, -1)?.path, saved.path)
+})
+
+test('tab labels follow Entity, Record, and Page routes', () => {
+  const label = (slug: string) => slug === 'customers' ? 'Customers' : ''
+  assert.equal(tabLabelForRoute({ name: RouteName.Home, path: '/', fullPath: '/', params: {} }, label), 'Home')
+  assert.equal(tabLabelForRoute({ name: RouteName.RecordNew, path: '/customers/new', fullPath: '/customers/new', params: { entity: 'customers' } }, label), 'New Customers')
+  assert.equal(tabLabelForRoute({ name: RouteName.RecordDetail, path: '/customers/CUS-1', fullPath: '/customers/CUS-1', params: { entity: 'customers', recordName: 'CUS-1' } }, label), 'Customers / CUS-1')
+  assert.equal(tabLabelForRoute({ name: 'page:crm:pipeline', path: '/pipeline', fullPath: '/pipeline', params: {} }, label), 'Pipeline')
+})
+
+test('each newly opened tab receives a distinct cache identity', () => {
+  const first = normalizeStudioTabs([{ path: '/customers/CUS-1', fullPath: '/customers/CUS-1', label: 'Customer' }])
+  const second = normalizeStudioTabs([{ path: '/customers/CUS-1', fullPath: '/customers/CUS-1', label: 'Customer' }])
+  assert.notEqual(first[0]?.cacheKey, second[0]?.cacheKey)
+})

--- a/apps/studio/ui/src/features/tabs/tabs.ts
+++ b/apps/studio/ui/src/features/tabs/tabs.ts
@@ -1,0 +1,120 @@
+import { RouteName, routeParam } from '../../router/routes.ts'
+import { humanizeEntity } from '../../stores/metadata.identity.ts'
+
+export type StudioTab = {
+  path: string
+  fullPath: string
+  label: string
+  cacheKey?: string
+}
+
+export type TabRouteInfo = {
+  name?: string | symbol | null
+  path: string
+  fullPath: string
+  params: Record<string, unknown>
+}
+
+let nextTabCacheKey = 0
+
+export function normalizeStudioTabs(value: unknown): StudioTab[] {
+  if (!Array.isArray(value)) return []
+
+  const seen = new Set<string>()
+  return value.flatMap((candidate): StudioTab[] => {
+    if (!candidate || typeof candidate !== 'object') return []
+    const item = candidate as Record<string, unknown>
+    const path = normalizeTabPath(item.path)
+    const fullPath = typeof item.fullPath === 'string' && item.fullPath.startsWith('/') ? item.fullPath : path
+    const label = typeof item.label === 'string' ? item.label.trim() : ''
+    if (!path || !label) return []
+    if (seen.has(path)) return []
+    seen.add(path)
+    return [{ path, fullPath, label, cacheKey: validCacheKey(item.cacheKey) ?? createTabCacheKey(path) }]
+  })
+}
+
+export function upsertStudioTab(tabs: StudioTab[], tab: StudioTab): StudioTab[] {
+  const index = tabs.findIndex(item => item.path === tab.path)
+  if (index === -1) return [...tabs, { ...tab, cacheKey: tab.cacheKey ?? createTabCacheKey(tab.path) }]
+  return tabs.map((item, itemIndex) => itemIndex === index ? { ...item, fullPath: tab.fullPath, label: tab.label || item.label } : item)
+}
+
+export function morphStudioTab(tabs: StudioTab[], fromPath: string, tab: StudioTab): StudioTab[] {
+  const fromIndex = tabs.findIndex(item => item.path === fromPath)
+  const without = tabs.filter(item => item.path !== fromPath && item.path !== tab.path)
+  const insertAt = fromIndex === -1 ? without.length : Math.min(fromIndex, without.length)
+  return [...without.slice(0, insertAt), tab, ...without.slice(insertAt)]
+}
+
+export function closeStudioTab(tabs: StudioTab[], path: string, activePath: string): { tabs: StudioTab[], activate: StudioTab | null, closed: boolean } {
+  if (tabs.length <= 1) return { tabs, activate: null, closed: false }
+  const index = tabs.findIndex(item => item.path === path)
+  if (index === -1) return { tabs, activate: null, closed: false }
+  const next = tabs.filter(item => item.path !== path)
+  if (path !== activePath) return { tabs: next, activate: null, closed: true }
+  return { tabs: next, activate: next[index] ?? next[index - 1] ?? null, closed: true }
+}
+
+export function cycleStudioTab(tabs: StudioTab[], activePath: string, delta: number): StudioTab | null {
+  if (tabs.length < 2) return null
+  const index = tabs.findIndex(item => item.path === activePath)
+  if (index === -1) return tabs[0] ?? null
+  const nextIndex = ((index + delta) % tabs.length + tabs.length) % tabs.length
+  return tabs[nextIndex] ?? null
+}
+
+export function shouldMorphNewRecordTab(fromPath: string, toPath: string): boolean {
+  const from = fromPath.match(/^\/([^/]+)\/new$/)
+  const to = toPath.match(/^\/([^/]+)\/([^/]+)$/)
+  return Boolean(from && to && from[1] === to[1] && to[2] !== 'new')
+}
+
+export function tabLabelForRoute(route: TabRouteInfo, entityLabel: (slug: string) => string): string {
+  const name = typeof route.name === 'string' ? route.name : ''
+  if (name === RouteName.Home || route.path === '/') return 'Home'
+  if (name === RouteName.NotFound) return 'Not found'
+  const entity = paramValue(route.params.entity)
+  if (name === RouteName.EntityRecords) return entityLabel(entity) || humanizeEntity(entity) || 'Records'
+  if (name === RouteName.RecordNew) {
+    const label = entityLabel(entity) || humanizeEntity(entity)
+    return label ? `New ${label}` : 'New Record'
+  }
+  if (name === RouteName.RecordDetail) {
+    const record = paramValue(route.params.recordName)
+    const label = entityLabel(entity) || humanizeEntity(entity)
+    return record ? `${label} / ${record}` : label || 'Record'
+  }
+  if (name.startsWith('page:')) {
+    const key = name.slice(name.lastIndexOf(':') + 1)
+    return humanizeEntity(key) || 'Page'
+  }
+  const leaf = route.path.replace(/\/+$/, '').split('/').at(-1) ?? ''
+  return humanizeEntity(leaf) || 'Page'
+}
+
+export function tabCacheKey(tabs: StudioTab[], path: string, epoch: number): string {
+  const tab = tabs.find(item => item.path === path)
+  return `${tab?.cacheKey ?? path}::${epoch}`
+}
+
+function createTabCacheKey(path: string): string {
+  nextTabCacheKey += 1
+  return `${path}::tab-${nextTabCacheKey}`
+}
+
+function validCacheKey(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null
+}
+
+function normalizeTabPath(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const path = value.trim()
+  if (path === '' || !path.startsWith('/') || path.startsWith('//') || path.includes('?') || path.includes('#')) return ''
+  return path.length > 1 ? path.replace(/\/+$/, '') : path
+}
+
+function paramValue(value: unknown): string {
+  if (typeof value === 'string' || Array.isArray(value)) return routeParam(value)
+  return ''
+}

--- a/apps/studio/ui/src/features/tabs/use-close-tab.ts
+++ b/apps/studio/ui/src/features/tabs/use-close-tab.ts
@@ -1,0 +1,29 @@
+import { useRouter } from 'vue-router'
+
+import { useDialog } from '@/features/dialogs/use-dialog'
+import { useNavigationStore } from '@/stores/navigation.store'
+
+export function useCloseTab() {
+  const dialog = useDialog()
+  const navigation = useNavigationStore()
+  const router = useRouter()
+
+  return async (path: string) => {
+    if (navigation.isTabDirty(path)) {
+      const result = await dialog.confirm({
+        title: 'Discard changes?',
+        content: 'Unsaved changes will be lost.',
+        type: 'warning',
+        actions: [
+          { key: 'cancel', label: 'Keep editing', variant: 'secondary' },
+          { key: 'discard', label: 'Discard changes', variant: 'danger' },
+        ],
+      })
+      if (result !== 'discard') return
+      navigation.setTabDirty(path, false)
+    }
+
+    const activate = navigation.closeTab(path, router.currentRoute.value.path)
+    if (activate) await router.push(activate.fullPath)
+  }
+}

--- a/apps/studio/ui/src/pages/RecordFormPage.vue
+++ b/apps/studio/ui/src/pages/RecordFormPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, onScopeDispose, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { usePageCommands, runStudioCommand } from '@/features/commands/context'
 import { bindings } from '@/features/commands/shortcuts'
 import { useDraftGuard } from '@/features/records/use-draft-guard'
@@ -42,6 +42,8 @@ import type { PageHeaderAction } from '@/shell/types'
 import { humanizeEntity } from '@/stores/metadata.identity'
 import { statusForError, storeError, type LoadStatus } from '@/stores/status'
 import type { PinnedItem } from '@/features/pinned/pinned'
+import { useSheetActive } from '@/features/tabs/sheet-active'
+import { useNavigationStore } from '@/stores/navigation.store'
 
 const props = defineProps<{
   entity: string
@@ -55,6 +57,10 @@ type ConvertedValue = {
 }
 
 const router = useRouter()
+const route = useRoute()
+const navigation = useNavigationStore()
+const sheetActive = useSheetActive()
+const sheetPath = route.path
 const dialog = useDialog()
 const toast = useToast()
 const entityMetaQuery = useMetadataEntityMetaQuery(() => props.entity)
@@ -231,6 +237,11 @@ const showForm = computed(() => Boolean(entityMeta.value) && (isNew.value || Boo
 const dirty = computed(() => fields.value.some((field) => !draftValuesEqual(draft.value[field.name], baseline.value[field.name])))
 const canSave = computed(() => showForm.value && dirty.value && !loading.value && !saving.value && !isSystem.value)
 const confirmDiscard = useDraftGuard(() => dirty.value, () => saving.value)
+watch([dirty, sheetActive], () => {
+  if (!sheetActive.value) return
+  navigation.setTabDirty(sheetPath, dirty.value)
+}, { immediate: true })
+onScopeDispose(() => navigation.setTabDirty(sheetPath, false))
 const saveDisabledReason = computed(() => isSystem.value ? 'Read-only Record' : loading.value ? 'Loading Record' : saving.value ? 'Saving Record' : !showForm.value ? 'Record unavailable' : !dirty.value ? 'No changes' : undefined)
 usePageCommands(computed(() => [
   { id: 'record:save', label: isNew.value ? 'Create Record' : 'Save Record', disabledReason: entityActionMutation.isPending.value ? 'Action is running' : saveDisabledReason.value, run: saveRecord },
@@ -309,11 +320,13 @@ watch(
     }
 
     if (meta?.['is-single'] && mode !== 'single') {
+      navigation.replaceTab(route.path, { path: `/${entity}`, fullPath: `/${entity}`, label: entityLabel.value })
       await router.replace({ name: RouteName.EntityRecords, params: { entity } })
       return
     }
 
     if (meta?.['is-system'] && mode === 'new') {
+      navigation.replaceTab(route.path, { path: `/${entity}`, fullPath: `/${entity}`, label: entityLabel.value })
       await router.replace({ name: RouteName.EntityRecords, params: { entity } })
       return
     }
@@ -506,6 +519,7 @@ async function deleteRecord() {
       id: currentRecordID(),
     })
     toast.success('Record deleted')
+    navigation.replaceTab(sheetPath, { path: `/${props.entity}`, fullPath: `/${props.entity}`, label: entityLabel.value })
     await router.replace({ name: RouteName.EntityRecords, params: { entity: props.entity } })
   } catch {
     // TanStack owns the mutation error for display.

--- a/apps/studio/ui/src/renderers/records/RecordListRenderer.vue
+++ b/apps/studio/ui/src/renderers/records/RecordListRenderer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useSheetActive } from '@/features/tabs/sheet-active'
 import { useInfiniteQuery, useQuery } from '@tanstack/vue-query'
 import { useStorage } from '@vueuse/core'
 import { ArrowDown, ArrowUp, Check, Download, Play, Settings2, X } from '@lucide/vue'
@@ -66,6 +67,7 @@ const emit = defineEmits<{
 
 const route = useRoute()
 const router = useRouter()
+const sheetActive = useSheetActive()
 const platformConfigQuery = usePlatformConfigQuery()
 const preferences = usePreferencesStore()
 const auth = useAuthStore()
@@ -332,10 +334,12 @@ watch(
   () => [
     props.entity,
     route.query,
+    sheetActive.value,
     filterableFields.value.map((field) => `${field.name}:${field.filter?.operators?.map((operator) => operator.key).join(',') ?? ''}`).join('|'),
     columns.value.map((column) => `${column.key}:${column.sortable ? '1' : '0'}`).join('|'),
   ] as const,
   () => {
+    if (!sheetActive.value) return
     if (currentEntity !== props.entity) {
       clearScheduledRecordListRouteReplace()
       selectedRowKeys.value = []
@@ -722,6 +726,7 @@ function clearKeepViewOptionsOpenTimer() {
 }
 
 function replaceRecordListRoute(filters: RecordListFilter[], sort: DataTableSort | null) {
+  if (!sheetActive.value) return
   const nextQuery = buildRecordListRouteQuery({ filters, sort })
   if (recordListRouteQueriesEqual(route.query, nextQuery)) {
     return
@@ -759,7 +764,7 @@ function appliedRecordFilters(): RecordListFilter[] {
 
 function routeRecordListQuery(): RecordListRouteState {
   const canonical = canonicalizeRecordListRouteQuery(route.query, recordListRouteSchema())
-  if (canonical.changed) {
+  if (canonical.changed && sheetActive.value) {
     void router.replace({ query: canonical.query })
   }
 

--- a/apps/studio/ui/src/router/current.test.ts
+++ b/apps/studio/ui/src/router/current.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { studioPathIsEntity, studioPinIsCurrent, studioPathsEqual } from './current.ts'
+
+test('entity navigation stays current on Record URLs', () => {
+  const record = '/constraint/studio.preference.preference-user-key-key'
+  assert.equal(studioPathIsEntity(record, 'constraint'), true)
+  assert.equal(studioPathIsEntity('/constraint', 'constraint'), true)
+  assert.equal(studioPathIsEntity('/constraint/new', 'constraint'), true)
+  assert.equal(studioPathIsEntity(record, 'preference'), false)
+  assert.equal(studioPathIsEntity('/constraint-type/x', 'constraint'), false)
+})
+
+test('entity pins stay current on child Record paths', () => {
+  const record = '/constraint/studio.preference.preference-user-key-key'
+  assert.equal(studioPinIsCurrent('entity', '/constraint', record), true)
+  assert.equal(studioPinIsCurrent('entity', '/constraint', '/constraint'), true)
+  assert.equal(studioPinIsCurrent('record', record, record), true)
+  assert.equal(studioPinIsCurrent('record', record, '/constraint'), false)
+  assert.equal(studioPinIsCurrent('page', '/', record), false)
+  assert.equal(studioPathsEqual('/customers/CUS-1', '/customers/CUS-1'), true)
+})

--- a/apps/studio/ui/src/router/current.ts
+++ b/apps/studio/ui/src/router/current.ts
@@ -1,0 +1,28 @@
+export function studioPathsEqual(left: string, right: string): boolean {
+  return decodePath(left) === decodePath(right)
+}
+
+export function studioPathIsEntity(path: string, slug: string): boolean {
+  return pathIsUnder(path, `/${slug}`)
+}
+
+export function studioPinIsCurrent(type: 'entity' | 'page' | 'record', pinPath: string | null, routePath: string): boolean {
+  if (!pinPath) return false
+  if (type === 'entity') return pathIsUnder(routePath, pinPath)
+  return studioPathsEqual(pinPath, routePath)
+}
+
+function pathIsUnder(path: string, prefix: string): boolean {
+  const current = decodePath(path)
+  const base = decodePath(prefix)
+  if (base === '/') return current === '/'
+  return current === base || current.startsWith(`${base}/`)
+}
+
+function decodePath(path: string): string {
+  try {
+    return decodeURI(path)
+  } catch {
+    return path
+  }
+}

--- a/apps/studio/ui/src/shell/Shell.vue
+++ b/apps/studio/ui/src/shell/Shell.vue
@@ -14,6 +14,8 @@ import type { ShellNavItem } from './types'
 import PageSheet from './PageSheet.vue'
 import Sidebar from './Sidebar.vue'
 import TopBar from './TopBar.vue'
+import PageTabs from '@/features/tabs/PageTabs.vue'
+import { useCloseTab } from '@/features/tabs/use-close-tab'
 
 const props = withDefaults(defineProps<{
   brandLabel?: string
@@ -31,11 +33,12 @@ const props = withDefaults(defineProps<{
 })
 
 const navigationStore = useNavigationStore()
-const { sidebarCollapsed } = storeToRefs(navigationStore)
+const { sidebarCollapsed, openTabs } = storeToRefs(navigationStore)
 const router = useRouter()
 const boot = useBootStore()
 const auth = useAuthStore()
 const desktop = useMediaQuery('(min-width: 721px)')
+const closeTab = useCloseTab()
 const commands = computed(() => auth.currentUser ? [
   { id: 'app:palette', label: 'Open command palette', group: 'Studio', run: () => { navigationStore.commandMenuOpen = !navigationStore.commandMenuOpen } },
   { id: 'app:shortcuts', label: 'Keyboard shortcuts', group: 'Studio', run: () => { navigationStore.shortcutsOpen = true } },
@@ -44,6 +47,15 @@ const commands = computed(() => auth.currentUser ? [
   { id: 'app:home', label: 'Go home', group: 'Studio', run: async () => {
     const home = boot.defaults?.home
     await router.push(typeof home === 'string' && home.startsWith('/') && !home.startsWith('//') ? home : '/')
+  } },
+  { id: 'app:tab-close', label: 'Close tab', group: 'Studio', disabledReason: openTabs.value.length <= 1 ? 'The last tab stays open' : undefined, run: () => closeTab(router.currentRoute.value.path) },
+  { id: 'app:tab-next', label: 'Next tab', group: 'Studio', disabledReason: openTabs.value.length < 2 ? 'No other tab is open' : undefined, run: async () => {
+    const tab = navigationStore.cycleTab(router.currentRoute.value.path, 1)
+    if (tab) await router.push(tab.fullPath)
+  } },
+  { id: 'app:tab-previous', label: 'Previous tab', group: 'Studio', disabledReason: openTabs.value.length < 2 ? 'No other tab is open' : undefined, run: async () => {
+    const tab = navigationStore.cycleTab(router.currentRoute.value.path, -1)
+    if (tab) await router.push(tab.fullPath)
   } },
 ] : [])
 watchEffect(() => { globalCommands.value = commands.value })
@@ -77,6 +89,7 @@ useShortcuts()
     </Sidebar>
 
     <div class="studio-shell__sheet">
+      <PageTabs />
       <PageSheet>
         <slot />
       </PageSheet>
@@ -129,6 +142,7 @@ useShortcuts()
   min-width: 0;
   grid-column: 2;
   grid-row: 2;
+  grid-template-rows: auto minmax(0, 1fr);
   overflow: visible;
   padding: 0 var(--studio-shell-sheet-right-gutter) 0 0;
 }

--- a/apps/studio/ui/src/stores/navigation.store.test.ts
+++ b/apps/studio/ui/src/stores/navigation.store.test.ts
@@ -81,3 +81,48 @@ test('a page visited during hydration keeps server history', async () => {
     globalThis.fetch = original
   }
 })
+
+test('open tabs stay in the browser tab and survive reload without wiping', () => {
+  const session = memoryStorage()
+  const hadWindow = 'window' in globalThis
+  const previousWindow = globalThis.window
+  Object.defineProperty(globalThis, 'window', { configurable: true, value: { sessionStorage: session, localStorage: memoryStorage() } })
+  const originalFetch = globalThis.fetch
+  const writes: string[] = []
+  globalThis.fetch = async (_input, init) => {
+    if (init?.method === 'PUT') writes.push(String(_input))
+    return Response.json({ data: { 'studio.open-tabs': [{ path: '/server', fullPath: '/server', label: 'Server' }] } })
+  }
+
+  try {
+    setActivePinia(createPinia())
+    const first = useNavigationStore()
+    first.setRecentUser(7)
+    first.syncTab({ path: '/constraint', fullPath: '/constraint', label: 'Constraint' })
+    first.syncTab({ path: '/constraint/studio.preference.preference-user-key-key', fullPath: '/constraint/studio.preference.preference-user-key-key', label: 'Constraint / record' })
+    first.closeTab('/constraint', '/constraint/studio.preference.preference-user-key-key')
+    assert.deepEqual(first.openTabs.map(tab => tab.path), ['/constraint/studio.preference.preference-user-key-key'])
+    assert.equal(writes.some(url => url.includes('studio.open-tabs')), false)
+
+    setActivePinia(createPinia())
+    const reloaded = useNavigationStore()
+    reloaded.setRecentUser(7)
+    reloaded.syncTab({ path: '/constraint/studio.preference.preference-user-key-key', fullPath: '/constraint/studio.preference.preference-user-key-key', label: 'Constraint / record' })
+    assert.deepEqual(reloaded.openTabs.map(tab => tab.path), ['/constraint/studio.preference.preference-user-key-key'])
+
+    const otherSession = memoryStorage()
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { sessionStorage: otherSession, localStorage: memoryStorage() } })
+    setActivePinia(createPinia())
+    const otherTab = useNavigationStore()
+    otherTab.setRecentUser(7)
+    otherTab.syncTab({ path: '/user', fullPath: '/user', label: 'User' })
+    assert.deepEqual(otherTab.openTabs.map(tab => tab.path), ['/user'])
+  } finally {
+    globalThis.fetch = originalFetch
+    if (hadWindow) {
+      Object.defineProperty(globalThis, 'window', { configurable: true, value: previousWindow })
+    } else {
+      delete (globalThis as { window?: unknown }).window
+    }
+  }
+})

--- a/apps/studio/ui/src/stores/navigation.store.ts
+++ b/apps/studio/ui/src/stores/navigation.store.ts
@@ -1,6 +1,16 @@
 import { defineStore } from 'pinia'
 import { usePreferencesStore } from '../features/preferences/preferences.store.ts'
 import { normalizePinnedItems, pinnedItemID, type PinnedItem } from '../features/pinned/pinned.ts'
+import {
+  closeStudioTab,
+  cycleStudioTab,
+  morphStudioTab,
+  normalizeStudioTabs,
+  shouldMorphNewRecordTab,
+  tabCacheKey,
+  upsertStudioTab,
+  type StudioTab,
+} from '../features/tabs/tabs.ts'
 
 export type RecentPage = {
   path: string
@@ -9,6 +19,7 @@ export type RecentPage = {
 }
 
 const RECENT_PAGES_STORAGE_KEY = 'dygo.studio.recentPages'
+const OPEN_TABS_STORAGE_KEY = 'dygo.studio.openTabs'
 const MAX_RECENT_PAGES = 10
 
 export const useNavigationStore = defineStore('navigation', {
@@ -19,6 +30,8 @@ export const useNavigationStore = defineStore('navigation', {
     shortcutsOpen: false,
     recordSearchRequested: false,
     routeReloadVersion: 0,
+    dirtyTabPaths: [] as string[],
+    openTabs: [] as StudioTab[],
   }),
 
   getters: {
@@ -36,6 +49,8 @@ export const useNavigationStore = defineStore('navigation', {
       this.commandMenuOpen = false
       this.shortcutsOpen = false
       this.recordSearchRequested = false
+      this.dirtyTabPaths = []
+      this.openTabs = userID === null ? [] : readOpenTabs(userID)
       const preferences = usePreferencesStore()
       void preferences.startSession(userID)
       if (userID !== null) void preferences.importMissing({ 'studio.recent-pages': readRecentPages(userID) })
@@ -97,6 +112,59 @@ export const useNavigationStore = defineStore('navigation', {
       this.routeReloadVersion += 1
     },
 
+    tabCacheKey(path: string) {
+      return tabCacheKey(this.openTabs, path, this.routeReloadVersion)
+    },
+
+    isTabDirty(path: string) {
+      return this.dirtyTabPaths.includes(path)
+    },
+
+    setTabDirty(path: string, dirty: boolean) {
+      if (dirty) {
+        if (!this.dirtyTabPaths.includes(path)) this.dirtyTabPaths = [...this.dirtyTabPaths, path]
+        return
+      }
+      this.dirtyTabPaths = this.dirtyTabPaths.filter(item => item !== path)
+    },
+
+    setTabLabel(path: string, label: string) {
+      const nextLabel = label.trim()
+      if (!nextLabel) return
+      this.writeTabs(this.openTabs.map(tab => tab.path === path ? { ...tab, label: nextLabel } : tab))
+    },
+
+    syncTab(tab: StudioTab, previousPath = '') {
+      if (this.recentUserID === null) return
+      if (shouldMorphNewRecordTab(previousPath, tab.path)) {
+        this.replaceTab(previousPath, tab)
+        return
+      }
+      this.writeTabs(upsertStudioTab(this.openTabs, tab))
+    },
+
+    replaceTab(fromPath: string, tab: StudioTab) {
+      this.setTabDirty(fromPath, false)
+      this.writeTabs(morphStudioTab(this.openTabs, fromPath, tab))
+    },
+
+    closeTab(path: string, activePath: string) {
+      const result = closeStudioTab(this.openTabs, path, activePath)
+      if (!result.closed) return result.activate
+      this.setTabDirty(path, false)
+      this.writeTabs(result.tabs)
+      return result.activate
+    },
+
+    cycleTab(activePath: string, delta: number) {
+      return cycleStudioTab(this.openTabs, activePath, delta)
+    },
+
+    writeTabs(tabs: StudioTab[]) {
+      this.openTabs = normalizeStudioTabs(tabs)
+      if (this.recentUserID !== null) persistOpenTabs(this.recentUserID, this.openTabs)
+    },
+
     async rememberRecentPage(page: RecentPage | null) {
       if (!page || page.path.trim() === '' || page.label.trim() === '') {
         return
@@ -119,6 +187,26 @@ export const useNavigationStore = defineStore('navigation', {
 
 function recentPagesKey(userID: number): string {
   return `${RECENT_PAGES_STORAGE_KEY}.${userID}`
+}
+
+function openTabsKey(userID: number): string {
+  return `${OPEN_TABS_STORAGE_KEY}.${userID}`
+}
+
+function readOpenTabs(userID: number): StudioTab[] {
+  try {
+    return normalizeStudioTabs(JSON.parse(window.sessionStorage.getItem(openTabsKey(userID)) ?? '[]'))
+  } catch {
+    return []
+  }
+}
+
+function persistOpenTabs(userID: number, tabs: StudioTab[]) {
+  try {
+    window.sessionStorage.setItem(openTabsKey(userID), JSON.stringify(tabs))
+  } catch {
+    // Browser session storage is optional.
+  }
 }
 
 function readRecentPages(userID: number): RecentPage[] {

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -91,6 +91,22 @@ Studio saves signed-in preferences in the Studio Preference Entity. Theme, sound
 
 Pin an Entity, Page, or saved Record from its header to add it to the personal Pinned section above the main navigation. Pinned items follow the signed-in user. The section shows five items until See more is selected, and supports drag or keyboard reordering.
 
+## Page Tabs
+
+Studio keeps open Page Sheets in a tab strip above the current sheet.
+
+Each tab is one route path. Entity lists, Records, New Record forms, reports, custom Pages, and other route-backed Page Types each get their own tab. Opening a path that is already open activates that tab. Query state such as list filters stays on that tab.
+
+The browser URL always matches the active tab. Back and Forward activate an open tab when that path is still open, or open a new tab.
+
+Switching tabs keeps Record drafts on the hidden sheet. Closing a dirty tab asks for confirmation. The last tab stays open. Creating a Record replaces the New Record tab with the saved Record tab.
+
+Open tabs belong to the current browser tab. Reload restores them in that browser tab. They do not follow the signed-in user across other browser tabs or devices.
+
+Tabs are horizontally scrollable when they exceed the available width. Tabs are not pinned: Pinned navigation is a separate persistent sidebar shortcut. Dirty state currently applies to Record forms; other Page Types need their own draft contract before Studio can mark them dirty.
+
+Close tab, Next tab, and Previous tab are available from the command palette. They do not bind Mod+W, so the browser can still close its own tab.
+
 ## Record List Filters
 
 Use Add filter to search available Field labels and names. Value controls follow Field metadata: options, booleans, dates, datetimes, numbers, and Links. Link choices respect Record permissions and dependent filters. Clear all removes filters and ID search while keeping sort and display choices.
@@ -125,15 +141,15 @@ Choose Search records, select an Entity, and type part of a Record ID. On an Ent
 | New Record | Mod+Enter | Entity list, outside input fields |
 | Toggle sidebar | Mod+\\ | When sidebar collapse is available |
 
-Open Keyboard shortcuts from the user menu or command palette to search current commands and disabled reasons. Record search, ID-search focus, Add filter, Reset changes, Home, and Entity-list navigation are available from the palette without extra key bindings.
+Open Keyboard shortcuts from the user menu or command palette to search current commands and disabled reasons. Record search, ID-search focus, Add filter, Reset changes, Home, Entity-list navigation, Close tab, Next tab, and Previous tab are available from the palette without extra key bindings.
 
 Studio matches exact modifiers and character keys. It ignores repeat, composition, AltGraph, and handled events. Dialogs, menus, and popovers keep keyboard control. Save is reserved on Record forms even when disabled, so it does not open the browser Save Page dialog. Browser Back, Forward, Find, Reload, Location, and New Window shortcuts are unchanged.
 
-Reset requires confirmation. Route navigation also requires confirmation when a Record form has unsaved changes. Failed saves and background refreshes preserve the draft. Navigation does not save automatically.
+Reset requires confirmation. Closing a dirty tab requires confirmation. Switching tabs keeps the draft on the hidden Page Sheet. Failed saves and background refreshes preserve the draft. Navigation does not save automatically.
 
 ### Internal registration
 
-Use `features/commands/context.ts` to register reactive current-page commands with `usePageCommands`. Supply a stable ID, label, optional group, disabled reason, and handler. The most recently mounted page owns the active commands; updates from background pages cannot replace it. Disposal removes that page's commands.
+Use `features/commands/context.ts` to register reactive current-page commands with `usePageCommands`. Supply a stable ID, label, optional group, disabled reason, and handler. The active Page Sheet owns the current-page commands. Hidden sheets unregister while they are in the background; a later activation restores them. Disposal removes that page's commands.
 
 Keep default keys and input policy in `features/commands/shortcuts.ts`. All bindings require Mod. The shell installs one listener. `runStudioCommand` and `executeCommand` share eligibility and in-flight checks for buttons, palette selection, and shortcuts. Focus actions execute after the palette closes and restores focus. Help and key badges use the same bindings.
 


### PR DESCRIPTION
## Summary
- add route-backed Studio tabs for lists, Records, forms, reports, and custom Pages
- preserve hidden sheet state and dirty Record drafts
- add close, next, previous, overflow, persistence, accessibility, and route-state handling
- document the tab model and browser-history behavior

## Images
<img width="1628" height="325" alt="image" src="https://github.com/user-attachments/assets/df40a075-c848-4aa8-8d92-4582e1f29d4e" />
<img width="2804" height="428" alt="image" src="https://github.com/user-attachments/assets/75503e5a-bcc6-42ed-983c-f1d71993fcc6" />
<img width="2690" height="1034" alt="image" src="https://github.com/user-attachments/assets/37ffb2c0-ac83-406a-8273-112a16efbb92" />


## Verification
- npm test (101 passed)
- npm run build
- git diff --check

Closes #127
Closes #197